### PR TITLE
chore(github): botão Sponsor no repo (GitHub Sponsors + bagre.dev/apoie)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+# Botão "Sponsor" no topo do repositório.
+# Docs: https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+github: fabgcruz
+custom:
+  - "https://bagre.dev/apoie"


### PR DESCRIPTION
Adiciona `.github/FUNDING.yml` pra o GitHub exibir o botão **Sponsor** no topo do repositório, reforçando os canais de apoio do projeto:

- **GitHub Sponsors**: `fabgcruz`
- **Link custom**: https://bagre.dev/apoie (GitHub Sponsors + Pix)

Sem impacto em código ou runtime.
