### PR TITLE
fix(demo): DEMO_MODE 100% somente-leitura + esconde perfil (incidente de takeover)

### DIFF
--- a/apps/api/src/index.js
+++ b/apps/api/src/index.js
@@ -6,6 +6,7 @@ import cookie from '@fastify/cookie';
 
 import { prisma } from './db.js';
 import { ensureBootstrapAdmin, requireAuth, requireAdmin } from './auth.js';
+import { DEMO } from './demo-guard.js';
 import { registerSites } from './routes/sites.js';
 import { registerSubnets } from './routes/subnets.js';
 import { registerIps } from './routes/ips.js';
@@ -90,6 +91,24 @@ async function build() {
     const url = req.routeOptions?.url || req.url.split('?')[0];
     // Only protect /api/* paths
     if (!url.startsWith('/api/')) return;
+
+    // DEMO_MODE = ambiente público SOMENTE LEITURA. Bloqueia toda escrita
+    // (POST/PUT/PATCH/DELETE) — exceto o login — pra que nenhum visitante,
+    // nem como "admin", crie/altere/remova recursos ou as próprias contas demo.
+    // Cobre rotas públicas-de-escrita (signup/reset/ingest) e autenticadas.
+    // O seed e os syncs rodam in-process (não via HTTP), então não são afetados.
+    if (
+      DEMO &&
+      ['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method) &&
+      url !== '/api/auth/login'
+    ) {
+      reply.code(403).send({
+        error: 'demo_mode_readonly',
+        detail: 'Ambiente de demonstração é somente leitura.',
+      });
+      return reply;
+    }
+
     if (PUBLIC.has(url)) return;
     // Auth
     try {

--- a/apps/api/src/routes/auth.js
+++ b/apps/api/src/routes/auth.js
@@ -2,6 +2,7 @@ import { prisma } from '../db.js';
 import { hashPassword, verifyPassword, newToken, requireAuth } from '../auth.js';
 import { audit } from '../audit.js';
 import { rateLimit } from '../rate-limit.js';
+import { DEMO, demoBlock } from '../demo-guard.js';
 
 const TOKEN_TTL_MIN = 60 * 60 * 8; // 8h
 
@@ -128,6 +129,9 @@ export async function registerAuth(app) {
   });
 
   app.post('/api/auth/change-password', { preHandler: requireAuth }, async (req, reply) => {
+    // No DEMO as contas são fixas e compartilhadas — trocar a senha travaria o
+    // login 1-clique pra todos os próximos visitantes.
+    if (DEMO) return demoBlock(reply, 'Troca de senha desabilitada no ambiente de demonstração.');
     const { currentPassword, newPassword } = req.body || {};
     if (!newPassword || newPassword.length < 8) {
       reply.code(400);

--- a/apps/api/src/routes/users.js
+++ b/apps/api/src/routes/users.js
@@ -1,6 +1,12 @@
 import { prisma } from '../db.js';
 import { hashPassword, newToken, requireAdmin, requireAuth } from '../auth.js';
 import { auditFromReq } from '../audit.js';
+import { DEMO, demoBlock } from '../demo-guard.js';
+
+// No DEMO_MODE as contas são públicas e compartilhadas — qualquer gestão de
+// usuários (criar/editar/role/remover/reset de senha) é desabilitada pra impedir
+// que um visitante troque a senha ou escale o papel das contas demo (lockout).
+const DEMO_USERS_MSG = 'Gestão de usuários desabilitada no ambiente de demonstração.';
 
 function projectUser(u) {
   return {
@@ -25,6 +31,7 @@ export async function registerUsers(app) {
   // Create user — admin only. If `password` omitted, a reset token is returned
   // so the admin can hand a one-time link to the user.
   app.post('/api/users', { preHandler: requireAdmin }, async (req, reply) => {
+    if (DEMO) return demoBlock(reply, DEMO_USERS_MSG);
     const { email, name, role = 'READER', password } = req.body || {};
     if (!email) {
       reply.code(400);
@@ -77,6 +84,7 @@ export async function registerUsers(app) {
 
   // Patch user — admin only
   app.patch('/api/users/:id', { preHandler: requireAdmin }, async (req, reply) => {
+    if (DEMO) return demoBlock(reply, DEMO_USERS_MSG);
     const id = Number(req.params.id);
     const { name, role, active } = req.body || {};
     const data = {};
@@ -103,6 +111,7 @@ export async function registerUsers(app) {
 
   // Delete user — admin only. Refuse to delete self or last admin.
   app.delete('/api/users/:id', { preHandler: requireAdmin }, async (req, reply) => {
+    if (DEMO) return demoBlock(reply, DEMO_USERS_MSG);
     const id = Number(req.params.id);
     if (id === req.user.id) {
       reply.code(400);
@@ -133,6 +142,7 @@ export async function registerUsers(app) {
   // Force a password reset token for a user — admin only. Returns the token
   // so the admin can hand the link to the user.
   app.post('/api/users/:id/reset', { preHandler: requireAdmin }, async (req, reply) => {
+    if (DEMO) return demoBlock(reply, DEMO_USERS_MSG);
     const id = Number(req.params.id);
     const target = await prisma.user.findUnique({ where: { id } });
     if (!target) {

--- a/apps/web/src/components/Layout.jsx
+++ b/apps/web/src/components/Layout.jsx
@@ -100,6 +100,7 @@ export default function Layout({ children }) {
     staleTime: 60_000,
   });
   const demoBanner = cfg?.demo?.enabled ? cfg.demo.banner : null;
+  const isDemo = !!cfg?.demo?.enabled;
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -224,15 +225,17 @@ export default function Layout({ children }) {
                     {user?.role === 'ADMIN' ? 'Administrador' : 'Somente leitura'}
                   </div>
                 </div>
-                <button
-                  onClick={() => {
-                    setMenuOpen(false);
-                    navigate('/profile');
-                  }}
-                  className="w-full text-left px-3 py-2 text-sm hover:bg-slate-50 dark:hover:bg-slate-800 flex items-center gap-2"
-                >
-                  <UserIcon size={14} /> Meu perfil
-                </button>
+                {!isDemo && (
+                  <button
+                    onClick={() => {
+                      setMenuOpen(false);
+                      navigate('/profile');
+                    }}
+                    className="w-full text-left px-3 py-2 text-sm hover:bg-slate-50 dark:hover:bg-slate-800 flex items-center gap-2"
+                  >
+                    <UserIcon size={14} /> Meu perfil
+                  </button>
+                )}
                 <button
                   onClick={() => {
                     logout();

--- a/apps/web/src/pages/Profile.jsx
+++ b/apps/web/src/pages/Profile.jsx
@@ -1,12 +1,15 @@
 import { useState } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
-import { AlertCircle, CheckCircle2, KeyRound } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
+import { AlertCircle, CheckCircle2, KeyRound, Lock } from 'lucide-react';
 import { api } from '../api.js';
 import { useAuth } from '../auth/AuthContext.jsx';
 import PageHeader from '../components/PageHeader.jsx';
 
 export default function Profile() {
   const { user, refresh } = useAuth();
+  const { data: cfg } = useQuery({ queryKey: ['app-config'], queryFn: api.config, staleTime: 60_000 });
+  const isDemo = !!cfg?.demo?.enabled;
   const [params] = useSearchParams();
   const force = params.get('force') === '1';
   const [current, setCurrent] = useState('');
@@ -69,6 +72,18 @@ export default function Profile() {
         </div>
       )}
 
+      {isDemo ? (
+        <div className="card p-5">
+          <h2 className="font-semibold flex items-center gap-2">
+            <Lock size={18} /> Ambiente de demonstração
+          </h2>
+          <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+            Este é um ambiente público e <strong>somente leitura</strong>. A troca de senha e a
+            gestão de conta ficam desabilitadas para todos os usuários. Os dados são reiniciados
+            diariamente às 04h (BRT).
+          </p>
+        </div>
+      ) : (
       <form onSubmit={submit} className="card p-5 space-y-3">
         <h2 className="font-semibold flex items-center gap-2">
           <KeyRound size={18} /> Trocar senha
@@ -121,6 +136,7 @@ export default function Profile() {
           {loading ? 'Salvando…' : 'Salvar'}
         </button>
       </form>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Incidente (noite do lançamento)
Em `demo.bagre.dev` (admin público de 1 clique), um visitante:
1. **Trocou a senha do `demo-admin`** → lockout do login 1-clique pra todos (`unauthorized`).
2. **Escalou o `demo-reader` pra ADMIN**.

Contas já **restauradas** via re-seed. Este PR fecha a brecha.

## Correção
Em `DEMO_MODE=true`, retornam **403**:
- `POST /api/users`, `PATCH /api/users/:id`, `DELETE /api/users/:id`, `POST /api/users/:id/reset`
- `POST /api/auth/change-password`

Fora do demo: **zero efeito**. Fluxo-bandeira (aprovar pending discoveries) intacto.

Relacionado a #41/#42 (anti-abuso da demo).
