### PR TITLE
hardening(demo): trava origem — nginx só aceita tráfego do Cloudflare

### DIFF
--- a/infra/demo/nginx-demo.bagre.dev.conf
+++ b/infra/demo/nginx-demo.bagre.dev.conf
@@ -33,6 +33,29 @@ set_real_ip_from 172.64.0.0/13;
 set_real_ip_from 131.0.72.0/22;
 real_ip_header CF-Connecting-IP;
 
+# ---- Origem travada: só aceita conexão vinda do Cloudflare ----
+# Usa o IP REAL do peer TCP ($realip_remote_addr) — não o header CF-Connecting-IP,
+# que um atacante batendo direto no IP:8443 poderia forjar. Quem não vier das
+# faixas públicas do Cloudflare recebe 403 (ver `if` no server abaixo).
+geo $realip_remote_addr $from_cloudflare {
+    default 0;
+    173.245.48.0/20 1;
+    103.21.244.0/22 1;
+    103.22.200.0/22 1;
+    103.31.4.0/22 1;
+    141.101.64.0/18 1;
+    108.162.192.0/18 1;
+    190.93.240.0/20 1;
+    188.114.96.0/20 1;
+    197.234.240.0/22 1;
+    198.41.128.0/17 1;
+    162.158.0.0/15 1;
+    104.16.0.0/13 1;
+    104.24.0.0/14 1;
+    172.64.0.0/13 1;
+    131.0.72.0/22 1;
+}
+
 server {
     listen 8443 ssl;
     http2 on;
@@ -50,9 +73,9 @@ server {
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_prefer_server_ciphers off;
 
-    # Opcional (forte): recusa quem não vem do Cloudflare (acesso direto ao IP:8443).
-    # Descomente para travar:
-    #   if ($http_cf_connecting_ip = "") { return 403; }
+    # Origem travada: recusa acesso direto ao IP:8443 (só passa via Cloudflare).
+    # $from_cloudflare vem do bloco `geo` acima (IP real do peer, à prova de spoof).
+    if ($from_cloudflare = 0) { return 403; }
 
     server_tokens off;
     client_max_body_size 12m;     # imports CSV/XLSX/JSON; ajuste se precisar


### PR DESCRIPTION
Parte do hardening do demo público (defesa em profundidade).

## O quê
Bloco `geo $realip_remote_addr $from_cloudflare` + `if ($from_cloudflare = 0) return 403` no vhost do demo. Usa o **IP real do peer TCP** (não o header `CF-Connecting-IP`, que seria forjável num acesso direto ao IP:8443).

## Efeito (verificado em prod)
- Via Cloudflare → 200 ✅
- Direto no IP:8443 (fora das faixas CF) → **403** ✅

Força todo tráfego a passar pelo Cloudflare (WAF/rate-limit/bot/TLS). 

> Nota de deploy: o conf é bind-mount de arquivo único; após `git pull`/`reset` é preciso **recriar** o container demo-nginx (`--force-recreate`), não basta `nginx -s reload` (o inode antigo permanece montado).
