### PR TITLE
docs(security): SECURITY.md para 1.x + canal de reporte funcionando (#33)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,14 +2,14 @@
 
 ## Versões suportadas
 
-O Bagre está em 0.x — apenas a **última release minor** recebe correções de segurança.
+O Bagre está em **1.x**. A **última release** recebe correções de segurança.
 
 | Versão | Suporte |
 |---|---|
-| 0.2.x | ✅ Recebe patches |
-| 0.1.x | ❌ Atualize para 0.2.x |
+| 1.0.x | ✅ Recebe patches de segurança |
+| 0.x | ❌ Atualize para 1.0.x |
 
-A partir da 1.0.0 manteremos uma política de suporte estendido (a definir).
+Conforme novas versões saírem, mantemos sempre a release mais recente com patches. Vulnerabilidades em versões antigas se resolvem atualizando para a última.
 
 ## Reportando uma vulnerabilidade
 


### PR DESCRIPTION
Parte de #33, com foco em **segurança real** (não só doc).

## O que estava errado
- **Private Vulnerability Reporting estava DESLIGADO** no repo. A SECURITY.md mandava o pesquisador usar `security/advisories/new` — que **só funciona pra externos se estiver habilitado**. Ou seja, o canal de reporte de vuln estava **quebrado pra quem é de fora**.
- Tabela de versões suportadas desatualizada (0.2.x/0.1.x quando já estamos em 1.0.0).

## O que fiz
- ✅ **Habilitei Private Vulnerability Reporting** (via API) — canal de advisories agora funciona.
- ✅ **Dependabot alerts + security updates** habilitados (PRs automáticos pra dependência vulnerável).
- ✅ SECURITY.md: tabela de versões → **1.0.x**; linguagem 0.x → 1.x.

## Fora do escopo deste PR
O e-mail **@bagre.dev** (parte da #33) depende do Email Routing (#32). Como o **GitHub Security Advisories** já é o canal preferido (e melhor que e-mail pra vuln), a parte de segurança está resolvida; o e-mail de contato geral fica pra quando #32 for feito.
