### PR TITLE
feat(auth): LDAP/AD nativo — fundação [#48 fase 1]

### DIFF
--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bagre-api",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bagre-api",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "@aws-sdk/client-ec2": "^3.654.0",
         "@aws-sdk/client-sts": "^3.654.0",
@@ -19,6 +19,7 @@
         "bcryptjs": "^2.4.3",
         "fastify": "^4.28.1",
         "ip-cidr": "^4.0.2",
+        "ldapts": "^8.1.8",
         "openid-client": "^5.7.0",
         "prom-client": "^15.1.3",
         "xlsx": "^0.18.5"
@@ -1626,6 +1627,18 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/ldapts": {
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/ldapts/-/ldapts-8.1.8.tgz",
+      "integrity": "sha512-Wpdvo+/0DREIynYf2he2efHtjptr5zD7dpesSkZWJqfQdMEgSTytEIsSZVuoDSiiE1+SpXf3emZ7ewxGBTo7Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "strict-event-emitter-types": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/light-my-request": {
       "version": "5.14.0",
       "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.14.0.tgz",
@@ -2127,6 +2140,12 @@
       "engines": {
         "node": ">=4.0.0"
       }
+    },
+    "node_modules/strict-event-emitter-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
+      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==",
+      "license": "ISC"
     },
     "node_modules/string-width": {
       "version": "5.1.2",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,6 +23,7 @@
     "bcryptjs": "^2.4.3",
     "fastify": "^4.28.1",
     "ip-cidr": "^4.0.2",
+    "ldapts": "^8.1.8",
     "openid-client": "^5.7.0",
     "prom-client": "^15.1.3",
     "xlsx": "^0.18.5"

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -182,6 +182,30 @@ model OidcConfig {
   createdAt       DateTime  @default(now())
 }
 
+// Autenticação LDAP / Active Directory on-premises (bind direto, sem broker).
+// O login local (e o SSO/OIDC) continuam funcionando em paralelo — anti-lockout.
+model LdapConfig {
+  id              Int       @id @default(1)
+  enabled         Boolean   @default(false)
+  url             String? // ldap://host:389 ou ldaps://host:636
+  startTls        Boolean   @default(false) // StartTLS em cima do ldap:// (alternativa ao ldaps://)
+  bindDn          String? // service account p/ buscar usuários (ex: CN=svc-bagre,OU=svc,DC=corp,DC=local)
+  bindPassword    String? // senha do service account — nunca retornada crua à UI
+  baseDn          String? // base de busca (ex: DC=corp,DC=local)
+  userFilter      String    @default("(sAMAccountName={username})") // {username} é substituído no login
+  emailAttr       String    @default("mail")
+  nameAttr        String    @default("displayName")
+  groupAttr       String    @default("memberOf") // atributo do usuário que lista os grupos (DNs)
+  adminGroups     String[]  @default([]) // DNs de grupos que concedem ADMIN
+  autoProvision   Boolean   @default(true) // cria o usuário local no 1º login
+  defaultRole     Role      @default(READER)
+  lastTestedAt    DateTime?
+  lastTestStatus  String? // ok | error
+  lastTestMessage String?
+  updatedAt       DateTime  @updatedAt
+  createdAt       DateTime  @default(now())
+}
+
 model PasswordResetToken {
   id         Int       @id @default(autoincrement())
   userId     Int

--- a/apps/api/src/auth-providers/ldap.js
+++ b/apps/api/src/auth-providers/ldap.js
@@ -1,0 +1,147 @@
+// Provider de autenticação LDAP / Active Directory on-premises (bind direto).
+//
+// SEGURANÇA (priorizar sempre):
+//  - Valida a senha fazendo BIND COMO O USUÁRIO (não comparando hash) — é o jeito
+//    correto pra LDAP/AD.
+//  - REJEITA senha vazia: muitos servidores tratam "bind com senha vazia" como
+//    bind anônimo bem-sucedido → seria auth bypass. Nunca permitir.
+//  - ESCAPA o username no filtro de busca (RFC 4515) → anti LDAP-injection.
+//  - Usa TLS pro bind da senha (ldaps:// ou StartTLS); cert validado por padrão.
+//  - Conexão sempre encerrada (unbind no finally).
+//
+// O login local e o SSO/OIDC continuam em paralelo (anti-lockout).
+
+import { Client } from 'ldapts';
+import { prisma } from '../db.js';
+
+export async function getConfig() {
+  let cfg = await prisma.ldapConfig.findUnique({ where: { id: 1 } });
+  if (!cfg) cfg = await prisma.ldapConfig.create({ data: { id: 1 } });
+  return cfg;
+}
+
+export function isConfigured(cfg) {
+  return Boolean(cfg?.url && cfg?.baseDn && cfg?.userFilter);
+}
+
+// Escapa caracteres especiais de filtro LDAP (RFC 4515) — anti-injection.
+function escapeFilter(value) {
+  return String(value).replace(
+    /[\\*()\0]/g,
+    (c) => '\\' + c.charCodeAt(0).toString(16).padStart(2, '0'),
+  );
+}
+
+function makeClient(cfg) {
+  return new Client({
+    url: cfg.url,
+    timeout: 8000,
+    connectTimeout: 8000,
+    // cert validado por padrão. Para AD com CA interna, será preciso fornecer a CA
+    // (config futura). Não desligar a validação sem necessidade.
+    tlsOptions: { rejectUnauthorized: true },
+  });
+}
+
+async function withClient(cfg, fn) {
+  const client = makeClient(cfg);
+  try {
+    if (cfg.startTls) await client.startTLS({ rejectUnauthorized: true });
+    return await fn(client);
+  } finally {
+    try {
+      await client.unbind();
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+function pickAttr(entry, attr) {
+  const v = entry?.[attr];
+  return Array.isArray(v) ? v[0] : v;
+}
+
+function toArray(v) {
+  if (!v) return [];
+  return Array.isArray(v) ? v.map(String) : [String(v)];
+}
+
+/** Mapeia os grupos do AD para ADMIN/READER. */
+export function mapRole(cfg, groups) {
+  const admin = (cfg.adminGroups || []).map((g) => String(g).toLowerCase().trim()).filter(Boolean);
+  if (admin.length) {
+    const set = new Set(groups.map((g) => String(g).toLowerCase()));
+    if (admin.some((g) => set.has(g))) return 'ADMIN';
+  }
+  return cfg.defaultRole || 'READER';
+}
+
+/** Teste de conexão — usado pelo botão "Testar conexão" do admin. */
+export async function testConnection(cfg) {
+  if (!cfg?.url) return { ok: false, message: 'URL do LDAP ausente' };
+  try {
+    await withClient(cfg, async (client) => {
+      if (cfg.bindDn) await client.bind(cfg.bindDn, cfg.bindPassword || '');
+      if (cfg.baseDn) {
+        await client.search(cfg.baseDn, {
+          scope: 'base',
+          filter: '(objectClass=*)',
+          sizeLimit: 1,
+        });
+      }
+    });
+    return { ok: true, message: `OK — conectou em ${cfg.url}` };
+  } catch (err) {
+    return { ok: false, message: err.message };
+  }
+}
+
+/**
+ * Autentica username+password contra o AD/LDAP.
+ * @returns {Promise<null | {email, name, dn, groups, role}>} null se inválido.
+ */
+export async function authenticate(cfg, username, password) {
+  if (!cfg?.enabled || !isConfigured(cfg)) return null;
+  // Anti-bypass: senha/username vazios são rejeitados sempre.
+  if (!username || !password) return null;
+
+  const filter = cfg.userFilter.replace(/\{username\}/g, escapeFilter(username));
+
+  return withClient(cfg, async (client) => {
+    // 1) Bind de serviço pra buscar o usuário (ou anônimo, se sem bindDn).
+    if (cfg.bindDn) {
+      await client.bind(cfg.bindDn, cfg.bindPassword || '');
+    }
+    // 2) Busca o usuário pelo filtro.
+    const { searchEntries } = await client.search(cfg.baseDn, {
+      scope: 'sub',
+      filter,
+      attributes: [cfg.emailAttr, cfg.nameAttr, cfg.groupAttr],
+      sizeLimit: 2,
+    });
+    if (searchEntries.length !== 1) return null; // 0 = não existe; >1 = ambíguo
+    const entry = searchEntries[0];
+    const userDn = entry.dn;
+    if (!userDn) return null;
+
+    // 3) Re-bind COMO o usuário com a senha → valida a credencial.
+    try {
+      await client.bind(userDn, password);
+    } catch {
+      return null; // senha incorreta
+    }
+
+    // 4) Extrai claims e mapeia papel.
+    const email = pickAttr(entry, cfg.emailAttr) || username;
+    const name = pickAttr(entry, cfg.nameAttr) || username;
+    const groups = toArray(entry[cfg.groupAttr]);
+    return {
+      email: String(email).toLowerCase(),
+      name: String(name),
+      dn: userDn,
+      groups,
+      role: mapRole(cfg, groups),
+    };
+  });
+}

--- a/apps/api/src/index.js
+++ b/apps/api/src/index.js
@@ -22,6 +22,7 @@ import { registerDevices } from './routes/devices.js';
 import { registerPendingDiscoveries } from './routes/pending-discoveries.js';
 import { registerAuditRoutes } from './routes/audit.js';
 import { registerOidcRoutes } from './routes/oidc.js';
+import { registerLdapRoutes } from './routes/ldap.js';
 import { registerZabbixRoutes } from './routes/zabbix.js';
 import { registerPrometheusRoutes } from './routes/prometheus.js';
 import { registerCidrRoutes } from './routes/cidr.js';
@@ -156,6 +157,7 @@ async function build() {
   await registerPendingDiscoveries(app);
   await registerAuditRoutes(app);
   await registerOidcRoutes(app);
+  await registerLdapRoutes(app);
   await registerZabbixRoutes(app);
   await registerPrometheusRoutes(app);
   await registerCidrRoutes(app);

--- a/apps/api/src/routes/ldap.js
+++ b/apps/api/src/routes/ldap.js
@@ -1,0 +1,78 @@
+// Endpoints admin pra configurar autenticação LDAP / Active Directory.
+// Desligado por padrão — só responde quando um admin habilita.
+// (Escrita já é bloqueada no DEMO_MODE pelo guard global em index.js.)
+
+import { prisma } from '../db.js';
+import { requireAdmin } from '../auth.js';
+import { auditFromReq } from '../audit.js';
+import { getConfig, isConfigured, testConnection } from '../auth-providers/ldap.js';
+
+// Nunca devolve a senha do service account crua pra UI.
+function maskSecret(cfg) {
+  if (!cfg) return cfg;
+  const { bindPassword, ...rest } = cfg;
+  return { ...rest, hasBindPassword: !!bindPassword };
+}
+
+export async function registerLdapRoutes(app) {
+  app.get('/api/admin/ldap-config', { preHandler: requireAdmin }, async () => {
+    return maskSecret(await getConfig());
+  });
+
+  app.patch('/api/admin/ldap-config', { preHandler: requireAdmin }, async (req, reply) => {
+    const body = req.body || {};
+    const data = {};
+    const fields = [
+      'enabled',
+      'url',
+      'startTls',
+      'bindDn',
+      'baseDn',
+      'userFilter',
+      'emailAttr',
+      'nameAttr',
+      'groupAttr',
+      'adminGroups',
+      'autoProvision',
+      'defaultRole',
+    ];
+    for (const f of fields) {
+      if (f in body) data[f] = body[f];
+    }
+    // bindPassword: só atualiza se vier um valor real (não o mascarado).
+    if (body.bindPassword && !String(body.bindPassword).startsWith('••••')) {
+      data.bindPassword = body.bindPassword;
+    }
+    const before = await getConfig();
+    const after = await prisma.ldapConfig.update({ where: { id: 1 }, data });
+    await auditFromReq(req, {
+      entity: 'ldap_config',
+      entityId: 1,
+      action: 'update',
+      before: maskSecret(before),
+      after: maskSecret(after),
+    });
+    if (after.enabled && !isConfigured(after)) {
+      reply.code(400);
+      return {
+        error: 'LDAP habilitado mas faltam campos obrigatórios (url, baseDn, userFilter).',
+        config: maskSecret(after),
+      };
+    }
+    return maskSecret(after);
+  });
+
+  app.post('/api/admin/ldap-config/test', { preHandler: requireAdmin }, async () => {
+    const cfg = await getConfig();
+    const result = await testConnection(cfg);
+    await prisma.ldapConfig.update({
+      where: { id: 1 },
+      data: {
+        lastTestedAt: new Date(),
+        lastTestStatus: result.ok ? 'ok' : 'error',
+        lastTestMessage: result.message,
+      },
+    });
+    return result;
+  });
+}


### PR DESCRIPTION
Primeira fase da **autenticação LDAP/Active Directory on-premises** (issue #48 — pedida por Sérgio e reforçada pelo Fabricio). 

⚠️ **Não liga no login ainda** — esta PR é só a fundação (schema + provider + rotas de config). A integração com o login (fase 2) vem separada, testada contra um servidor LDAP real (OpenLDAP no demo, fase 4).

## O que entra
- **Modelo Prisma `LdapConfig`**: url (ldap/ldaps), StartTLS, bindDN + senha (service account), baseDN, filtro de busca (`{username}`), attrs de email/nome/grupo, `adminGroups` (DNs → ADMIN), autoProvision, defaultRole.
- **`auth-providers/ldap.js`** (lib `ldapts`): `testConnection()` + `authenticate()`.
- **Rotas admin** `/api/admin/ldap-config` (GET/PATCH/test) — senha do service account **mascarada**, nunca devolvida crua.

## 🔒 Segurança (priorizada)
- Valida a senha fazendo **bind COMO o usuário** (jeito correto pra LDAP/AD).
- **Rejeita senha vazia** → evita o clássico *anonymous-bind = sucesso* (auth bypass).
- **Escapa o username** no filtro (RFC 4515) → anti LDAP-injection.
- **TLS** (ldaps:// ou StartTLS) com cert validado por padrão.
- Conexão sempre encerrada (unbind no finally).
- Escrita de config já bloqueada no DEMO_MODE (guard global).

## Próximas fases
2. Wiring no login + provisionamento · 3. Frontend (tela de config) · 4. OpenLDAP no demo (testável ao vivo) · 5. Docs.
