### PR TITLE
feat(auth): LDAP/AD no login + OpenLDAP no demo [#48 fases 2+4]

### DIFF
--- a/apps/api/scripts/demo-seed.mjs
+++ b/apps/api/scripts/demo-seed.mjs
@@ -35,6 +35,14 @@ const DNS_URL = process.env.DEMO_DNS_URL || 'http://powerdns:8081';
 const DNS_KEY = process.env.DEMO_DNS_KEY || 'bagre-demo-key';
 const DNS_ZONE = process.env.DEMO_DNS_ZONE || 'lab.local';
 
+// LDAP/AD do demo — aponta pro OpenLDAP in-stack (interno, sem porta pública).
+const LDAP_URL = process.env.DEMO_LDAP_URL || 'ldap://openldap:1389';
+const LDAP_BIND_DN = process.env.DEMO_LDAP_BIND_DN || 'cn=admin,dc=corp,dc=local';
+const LDAP_BIND_PW = process.env.DEMO_LDAP_BIND_PW || 'adminpw';
+const LDAP_BASE_DN = process.env.DEMO_LDAP_BASE_DN || 'dc=corp,dc=local';
+const LDAP_USER_FILTER = process.env.DEMO_LDAP_USER_FILTER || '(cn={username})';
+const LDAP_ADMIN_GROUP = process.env.DEMO_LDAP_ADMIN_GROUP || '';
+
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 async function upsertDemoUser(email, password, role) {
@@ -144,6 +152,25 @@ async function wireDns() {
     update: { enabled: true, provider: 'powerdns', baseUrl: DNS_URL, apiKey: DNS_KEY, serverId: 'localhost', defaultZone: DNS_ZONE },
   });
   console.log(`[demo-seed] DNS (PowerDNS) fixado em ${DNS_URL} · zona ${DNS_ZONE}`);
+}
+
+async function wireLdap() {
+  await prisma.ldapConfig.upsert({
+    where: { id: 1 },
+    create: {
+      id: 1, enabled: true, url: LDAP_URL, bindDn: LDAP_BIND_DN, bindPassword: LDAP_BIND_PW,
+      baseDn: LDAP_BASE_DN, userFilter: LDAP_USER_FILTER,
+      emailAttr: 'mail', nameAttr: 'cn', groupAttr: 'memberOf',
+      adminGroups: LDAP_ADMIN_GROUP ? [LDAP_ADMIN_GROUP] : [],
+      autoProvision: true, defaultRole: 'READER',
+    },
+    update: {
+      enabled: true, url: LDAP_URL, bindDn: LDAP_BIND_DN, bindPassword: LDAP_BIND_PW,
+      baseDn: LDAP_BASE_DN, userFilter: LDAP_USER_FILTER,
+      adminGroups: LDAP_ADMIN_GROUP ? [LDAP_ADMIN_GROUP] : [],
+    },
+  });
+  console.log(`[demo-seed] LDAP/AD fixado em ${LDAP_URL} · base ${LDAP_BASE_DN}`);
 }
 
 async function initialDnsSync() {
@@ -282,6 +309,7 @@ async function main() {
   await wireZabbix();
   await wirePrometheus();
   await wireDns();
+  await wireLdap();
   await initialZabbixSync();
   await initialPrometheusSync();
   await initialDnsSync();

--- a/apps/api/src/routes/auth.js
+++ b/apps/api/src/routes/auth.js
@@ -3,6 +3,7 @@ import { hashPassword, verifyPassword, newToken, requireAuth } from '../auth.js'
 import { audit } from '../audit.js';
 import { rateLimit } from '../rate-limit.js';
 import { DEMO, demoBlock } from '../demo-guard.js';
+import * as ldapProvider from '../auth-providers/ldap.js';
 
 const TOKEN_TTL_MIN = 60 * 60 * 8; // 8h
 
@@ -13,47 +14,94 @@ const signupLimit = rateLimit({ name: 'signup', windowMs: 5 * 60_000, max: 20 })
 const resetLimit = rateLimit({ name: 'reset', windowMs: 5 * 60_000, max: 20 });
 
 export async function registerAuth(app) {
-  app.post('/api/auth/login', { preHandler: loginLimit }, async (req, reply) => {
-    const { email, password } = req.body || {};
-    if (!email || !password) {
-      reply.code(400);
-      return { error: 'email e password obrigatórios' };
-    }
-    const user = await prisma.user.findUnique({ where: { email: email.toLowerCase() } });
-    if (!user || !user.active) {
-      reply.code(401);
-      return { error: 'credenciais inválidas' };
-    }
-    const ok = await verifyPassword(password, user.passwordHash);
-    if (!ok) {
-      reply.code(401);
-      return { error: 'credenciais inválidas' };
-    }
-    await prisma.user.update({
-      where: { id: user.id },
-      data: { lastLoginAt: new Date() },
-    });
-    await audit({
-      entity: 'user',
-      entityId: user.id,
-      action: 'login',
-      actor: user.email,
-      ip: req.ip,
-    });
+  // Emite o token + audita + atualiza lastLoginAt. Reusado por login local e LDAP.
+  async function issueLogin(reply, user, ip, via = 'local') {
+    await prisma.user.update({ where: { id: user.id }, data: { lastLoginAt: new Date() } });
+    await audit({ entity: 'user', entityId: user.id, action: 'login', actor: `${user.email} (${via})`, ip });
     const token = await reply.jwtSign(
       { sub: String(user.id), role: user.role, email: user.email },
       { expiresIn: TOKEN_TTL_MIN },
     );
     return {
       token,
-      user: {
-        id: user.id,
-        email: user.email,
-        name: user.name,
-        role: user.role,
-        mustChangePwd: user.mustChangePwd,
-      },
+      user: { id: user.id, email: user.email, name: user.name, role: user.role, mustChangePwd: user.mustChangePwd },
     };
+  }
+
+  // Provisiona/atualiza o usuário local a partir de um login LDAP bem-sucedido.
+  async function provisionLdapUser(cfg, result) {
+    let user =
+      (await prisma.user.findUnique({ where: { externalId: result.dn } })) ||
+      (await prisma.user.findUnique({ where: { email: result.email } }));
+    if (!user) {
+      if (!cfg.autoProvision) return null;
+      user = await prisma.user.create({
+        data: {
+          email: result.email,
+          name: result.name,
+          authProvider: 'ldap',
+          externalId: result.dn,
+          externalGroups: result.groups,
+          role: result.role,
+          active: true,
+        },
+      });
+      await audit({ entity: 'user', entityId: user.id, action: 'create', actor: 'ldap', after: { email: user.email, role: user.role, authProvider: 'ldap' } });
+      return user;
+    }
+    return prisma.user.update({
+      where: { id: user.id },
+      data: {
+        authProvider: 'ldap',
+        externalId: result.dn,
+        externalGroups: result.groups,
+        name: user.name || result.name,
+        // só sobrescreve o papel se há adminGroups configurados; senão o admin gerencia manual.
+        role: cfg.adminGroups?.length ? result.role : user.role,
+      },
+    });
+  }
+
+  app.post('/api/auth/login', { preHandler: loginLimit }, async (req, reply) => {
+    const { email, password } = req.body || {};
+    if (!email || !password) {
+      reply.code(400);
+      return { error: 'email e password obrigatórios' };
+    }
+
+    // 1) Autenticação LOCAL — só se o usuário tem senha local.
+    const localUser = await prisma.user.findUnique({ where: { email: String(email).toLowerCase() } });
+    if (localUser && localUser.active && localUser.passwordHash) {
+      const ok = await verifyPassword(password, localUser.passwordHash);
+      if (ok) return issueLogin(reply, localUser, req.ip, 'local');
+    }
+
+    // 2) Autenticação LDAP/AD — se habilitada. O campo "email" é tratado como
+    //    username (ex.: sAMAccountName) e passado ao filtro do AD.
+    try {
+      const ldapCfg = await ldapProvider.getConfig();
+      if (ldapCfg.enabled && ldapProvider.isConfigured(ldapCfg)) {
+        const result = await ldapProvider.authenticate(ldapCfg, email, password);
+        if (result) {
+          const user = await provisionLdapUser(ldapCfg, result);
+          if (!user) {
+            reply.code(403);
+            return { error: 'Usuário válido no AD, mas provisionamento automático está desligado.' };
+          }
+          if (!user.active) {
+            reply.code(403);
+            return { error: 'Conta inativa' };
+          }
+          return issueLogin(reply, user, req.ip, 'ldap');
+        }
+      }
+    } catch (err) {
+      req.log.warn({ err: err.message }, 'erro na autenticação LDAP');
+      // cai pro 401 abaixo — não vaza detalhe do erro pro cliente.
+    }
+
+    reply.code(401);
+    return { error: 'credenciais inválidas' };
   });
 
   app.post('/api/auth/signup', { preHandler: signupLimit }, async (req, reply) => {

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -25,6 +25,11 @@ services:
       DEMO_DNS_URL: http://powerdns:8081
       DEMO_DNS_KEY: bagre-demo-key
       DEMO_DNS_ZONE: lab.local
+      DEMO_LDAP_URL: ldap://openldap:1389
+      DEMO_LDAP_BIND_DN: cn=admin,dc=corp,dc=local
+      DEMO_LDAP_BIND_PW: adminpw
+      DEMO_LDAP_BASE_DN: dc=corp,dc=local
+      DEMO_LDAP_USER_FILTER: "(cn={username})"
     # demo-seed roda em BACKGROUND pra o servidor subir na hora (evita 502 longo
     # no boot/reset enquanto os syncs rodam). Os syncs populam em paralelo.
     command:
@@ -122,6 +127,25 @@ services:
       - -c
       - "DB=/var/lib/powerdns/pdns.sqlite3; [ -f \"$$DB\" ] || sqlite3 \"$$DB\" < /usr/local/share/doc/pdns/schema.sqlite3.sql; pdnsutil --config-dir=/etc/powerdns create-zone lab.local 2>/dev/null || true; exec pdns_server --config-dir=/etc/powerdns --daemon=no"
     mem_limit: 96m
+    security_opt:
+      - no-new-privileges:true
+
+  # --- OpenLDAP do demo (auth LDAP/AD) — INTERNO, sem porta pública ---
+  # Usuários "AD" de exemplo p/ demonstrar login via LDAP ao vivo. Só o `api`
+  # alcança (rede default). Senhas públicas de propósito (é demo).
+  openldap:
+    image: bitnami/openldap:2.6
+    container_name: bagre-openldap
+    restart: unless-stopped
+    environment:
+      LDAP_ADMIN_USERNAME: admin
+      LDAP_ADMIN_PASSWORD: adminpw
+      LDAP_ROOT: dc=corp,dc=local
+      LDAP_USERS: alice,bob,carol
+      LDAP_PASSWORDS: alicepw,bobpw,carolpw
+      LDAP_USER_DC: people
+      LDAP_GROUP: ipam-users
+    mem_limit: 128m
     security_opt:
       - no-new-privileges:true
 


### PR DESCRIPTION
Continuação da #48 (fundação foi a #64). Agora o **login via LDAP/AD funciona**, com servidor de teste no demo.

## Fase 2 — wiring no login
- `/api/auth/login`: tenta **local** (se o usuário tem senha local) → se falhar/não houver, tenta **LDAP/AD**.
- **Provisiona/atualiza** o usuário local no 1º login (authProvider `ldap`, externalId=DN, grupos, papel via mapeamento).
- Erro de LDAP **não vaza** detalhe ao cliente (401 genérico).
- Login local + SSO/OIDC seguem em paralelo (anti-lockout).

## Fase 4 — demo testável (vitrine)
- **OpenLDAP** (bitnami) **interno** ao stack do demo (sem porta pública — seguro), com usuários AD de exemplo (alice/bob/carol).
- `demo-seed` fixa o `LdapConfig` no openldap interno.
- → **login via AD ao vivo no demo.bagre.dev**.

## Próximo (fases seguintes)
3. Frontend (tela de config LDAP) · mapeamento **grupo→ADMIN** (memberof overlay) · 5. docs.
