### PR TITLE
fix(demo): servidor LDAP de teste da imagem OFICIAL do Debian [#48]

### DIFF
--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -25,11 +25,12 @@ services:
       DEMO_DNS_URL: http://powerdns:8081
       DEMO_DNS_KEY: bagre-demo-key
       DEMO_DNS_ZONE: lab.local
-      DEMO_LDAP_URL: ldap://openldap:1389
+      DEMO_LDAP_URL: ldap://openldap:389
       DEMO_LDAP_BIND_DN: cn=admin,dc=corp,dc=local
       DEMO_LDAP_BIND_PW: adminpw
       DEMO_LDAP_BASE_DN: dc=corp,dc=local
       DEMO_LDAP_USER_FILTER: "(cn={username})"
+      DEMO_LDAP_ADMIN_GROUP: cn=ipam-admins,ou=groups,dc=corp,dc=local
     # demo-seed roda em BACKGROUND pra o servidor subir na hora (evita 502 longo
     # no boot/reset enquanto os syncs rodam). Os syncs populam em paralelo.
     command:
@@ -134,18 +135,10 @@ services:
   # Usuários "AD" de exemplo p/ demonstrar login via LDAP ao vivo. Só o `api`
   # alcança (rede default). Senhas públicas de propósito (é demo).
   openldap:
-    image: bitnami/openldap:2.6
+    build: ./infra/demo/openldap
     container_name: bagre-openldap
     restart: unless-stopped
-    environment:
-      LDAP_ADMIN_USERNAME: admin
-      LDAP_ADMIN_PASSWORD: adminpw
-      LDAP_ROOT: dc=corp,dc=local
-      LDAP_USERS: alice,bob,carol
-      LDAP_PASSWORDS: alicepw,bobpw,carolpw
-      LDAP_USER_DC: people
-      LDAP_GROUP: ipam-users
-    mem_limit: 128m
+    mem_limit: 256m
     security_opt:
       - no-new-privileges:true
 

--- a/infra/demo/openldap/Dockerfile
+++ b/infra/demo/openldap/Dockerfile
@@ -1,0 +1,25 @@
+# Servidor LDAP de TESTE do demo — construído da imagem OFICIAL do Debian.
+# slapd (OpenLDAP, software livre) com domínio corp.local, usuários de exemplo
+# e overlay memberof (pra mapear grupo -> papel). Interno ao stack, sem porta
+# pública. Senhas públicas de propósito (é demo).
+FROM debian:bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN set -eux; \
+    echo "slapd slapd/no_configuration boolean false" | debconf-set-selections; \
+    echo "slapd slapd/domain string corp.local" | debconf-set-selections; \
+    echo "slapd shared/organization string Corp" | debconf-set-selections; \
+    echo "slapd slapd/password1 password adminpw" | debconf-set-selections; \
+    echo "slapd slapd/password2 password adminpw" | debconf-set-selections; \
+    echo "slapd slapd/backend select MDB" | debconf-set-selections; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends slapd ldap-utils; \
+    rm -rf /var/lib/apt/lists/*
+
+COPY memberof.ldif /bootstrap/memberof.ldif
+COPY seed.ldif /bootstrap/seed.ldif
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 389
+ENTRYPOINT ["/entrypoint.sh"]

--- a/infra/demo/openldap/entrypoint.sh
+++ b/infra/demo/openldap/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Sobe o slapd, aplica o overlay memberof e semeia usuários/grupos (idempotente).
+set -e
+mkdir -p /var/run/slapd
+chown -R openldap:openldap /var/lib/ldap /etc/ldap/slapd.d /var/run/slapd 2>/dev/null || true
+
+# slapd em foreground (-d 0), em background do shell, pra poder semear depois.
+slapd -h "ldap:/// ldapi:///" -u openldap -g openldap -F /etc/ldap/slapd.d -d 0 &
+SLAPD_PID=$!
+
+# Espera ficar pronto.
+for i in $(seq 1 30); do
+  ldapsearch -Y EXTERNAL -H ldapi:/// -b cn=config -s base >/dev/null 2>&1 && break
+  sleep 1
+done
+
+# Overlay memberof (ignora se já aplicado).
+ldapmodify -Y EXTERNAL -H ldapi:/// -f /bootstrap/memberof.ldif >/dev/null 2>&1 || true
+# Usuários/grupos (ignora se já existem).
+ldapadd -x -D "cn=admin,dc=corp,dc=local" -w adminpw -f /bootstrap/seed.ldif >/dev/null 2>&1 || true
+
+echo "[openldap] pronto — base dc=corp,dc=local · usuarios: alice (admin), bob (reader)"
+wait "$SLAPD_PID"

--- a/infra/demo/openldap/memberof.ldif
+++ b/infra/demo/openldap/memberof.ldif
@@ -1,0 +1,15 @@
+# Habilita o overlay memberof (popula memberOf nos usuários a partir dos grupos)
+dn: cn=module{0},cn=config
+changetype: modify
+add: olcModuleLoad
+olcModuleLoad: memberof
+
+dn: olcOverlay=memberof,olcDatabase={1}mdb,cn=config
+changetype: add
+objectClass: olcOverlayConfig
+objectClass: olcMemberOf
+olcOverlay: memberof
+olcMemberOfRefInt: TRUE
+olcMemberOfGroupOC: groupOfNames
+olcMemberOfMemberAD: member
+olcMemberOfMemberOfAD: memberOf

--- a/infra/demo/openldap/seed.ldif
+++ b/infra/demo/openldap/seed.ldif
@@ -1,0 +1,30 @@
+dn: ou=people,dc=corp,dc=local
+objectClass: organizationalUnit
+ou: people
+
+dn: ou=groups,dc=corp,dc=local
+objectClass: organizationalUnit
+ou: groups
+
+dn: cn=alice,ou=people,dc=corp,dc=local
+objectClass: inetOrgPerson
+cn: alice
+sn: Anderson
+uid: alice
+mail: alice@corp.local
+displayName: Alice Anderson (TI)
+userPassword: alicepw
+
+dn: cn=bob,ou=people,dc=corp,dc=local
+objectClass: inetOrgPerson
+cn: bob
+sn: Brown
+uid: bob
+mail: bob@corp.local
+displayName: Bob Brown
+userPassword: bobpw
+
+dn: cn=ipam-admins,ou=groups,dc=corp,dc=local
+objectClass: groupOfNames
+cn: ipam-admins
+member: cn=alice,ou=people,dc=corp,dc=local


### PR DESCRIPTION
A imagem `bitnami/openldap` foi **descontinuada do Docker Hub** (2025). Atendendo ao pedido de **usar imagens confiáveis**, o servidor LDAP de teste do demo passa a ser **construído da imagem OFICIAL `debian:bookworm-slim`** + `slapd` (OpenLDAP, software livre) — cadeia de suprimentos confiável, sem depender de imagem comunitária.

## `infra/demo/openldap/`
- **Dockerfile** — debian oficial + slapd preconfig (domínio `corp.local`, admin `adminpw`).
- **seed.ldif** — `alice` e `bob` em `ou=people`; grupo `ipam-admins` com a alice.
- **memberof.ldif** — overlay memberof (popula `memberOf` → permite mapear **grupo → ADMIN**).
- **entrypoint.sh** — sobe slapd, aplica overlay, semeia (idempotente).

Interno ao stack (sem porta pública). **alice** ∈ ipam-admins → vira **ADMIN** no Bagre; **bob** → READER. Valida login LDAP **e** o mapeamento de papel.
