### PR TITLE
fix(auth): só usar tlsOptions em ldaps:// — LDAP plano quebrava [#48]

### DIFF
--- a/apps/api/src/auth-providers/ldap.js
+++ b/apps/api/src/auth-providers/ldap.js
@@ -33,14 +33,15 @@ function escapeFilter(value) {
 }
 
 function makeClient(cfg) {
-  return new Client({
-    url: cfg.url,
-    timeout: 8000,
-    connectTimeout: 8000,
-    // cert validado por padrão. Para AD com CA interna, será preciso fornecer a CA
-    // (config futura). Não desligar a validação sem necessidade.
-    tlsOptions: { rejectUnauthorized: true },
-  });
+  const opts = { url: cfg.url, timeout: 8000, connectTimeout: 8000 };
+  // tlsOptions SÓ pra ldaps:// — passar em ldap:// faz o ldapts tentar um
+  // handshake TLS que o servidor recusa ("socket disconnected before TLS").
+  // No StartTLS o cert é validado no client.startTLS() (ver withClient).
+  // Cert validado por padrão; AD com CA interna precisará fornecer a CA (futuro).
+  if ((cfg.url || '').startsWith('ldaps://')) {
+    opts.tlsOptions = { rejectUnauthorized: true };
+  }
+  return new Client(opts);
 }
 
 async function withClient(cfg, fn) {


### PR DESCRIPTION
Bug encontrado no teste end-to-end: o login LDAP **plano (ldap://)** falhava com *"Client network socket disconnected before secure TLS connection was established"*.

**Causa:** `makeClient` passava `tlsOptions` no construtor do ldapts **sempre** — em `ldap://` o ldapts tenta um handshake TLS que o servidor (sem TLS) recusa.

**Fix:** `tlsOptions` só quando `ldaps://`. No StartTLS o cert é validado no `client.startTLS()`. **Confirmado** com teste direto: bind do usuário funciona após o fix.

Diagnóstico completo: server OK (alice tem memberOf ipam-admins), senha válida bind direto OK, api alcança openldap:389 — só o handshake TLS indevido quebrava.