### PR TITLE
security: não vazar sufixo de segredos + ocultar topologia interna na demo

### DIFF
--- a/apps/api/src/demo-guard.js
+++ b/apps/api/src/demo-guard.js
@@ -24,3 +24,19 @@ export function stripDemoPinned(data, fields) {
   for (const f of fields) delete data[f];
   return data;
 }
+
+/**
+ * Em DEMO_MODE, oculta detalhes de CONEXÃO (host/URL/usuário/DN) das respostas
+ * de config admin. Na demo o "admin" é um visitante anônimo da internet, então
+ * topologia interna (ex.: `ldap://openldap:389`, `cn=admin,dc=corp,dc=local`)
+ * não deve vazar. Não substitui o mascaramento de SEGREDOS (que vale sempre) —
+ * é uma camada extra só pra demo. Fora da demo, retorna o objeto intacto.
+ */
+export function redactForDemo(obj, fields) {
+  if (!DEMO || !obj) return obj;
+  const out = { ...obj };
+  for (const f of fields) {
+    if (out[f] != null && out[f] !== '') out[f] = '•••• (oculto na demo)';
+  }
+  return out;
+}

--- a/apps/api/src/routes/auth.js
+++ b/apps/api/src/routes/auth.js
@@ -8,8 +8,13 @@ import * as ldapProvider from '../auth-providers/ldap.js';
 const TOKEN_TTL_MIN = 60 * 60 * 8; // 8h
 
 // Proteção contra brute force nos endpoints de auth (por IP, janela de 5min).
-// Thresholds generosos pra não atrapalhar uso legítimo nem o login 1-clique da demo.
-const loginLimit = rateLimit({ name: 'login', windowMs: 5 * 60_000, max: 50 });
+// O teto do login é configurável via LOGIN_RATE_MAX: mantemos um default
+// folgado o bastante pra um escritório atrás de NAT (vários usuários, mesmo IP),
+// mas o ambiente de demonstração público fixa um valor BEM mais apertado
+// (LOGIN_RATE_MAX=12 no docker-compose.demo.yml) — lá o login é o único write
+// exposto, então é a superfície que mais precisa ser blindada.
+const LOGIN_MAX = Math.max(3, Number(process.env.LOGIN_RATE_MAX) || 30);
+const loginLimit = rateLimit({ name: 'login', windowMs: 5 * 60_000, max: LOGIN_MAX });
 const signupLimit = rateLimit({ name: 'signup', windowMs: 5 * 60_000, max: 20 });
 const resetLimit = rateLimit({ name: 'reset', windowMs: 5 * 60_000, max: 20 });
 

--- a/apps/api/src/routes/dns.js
+++ b/apps/api/src/routes/dns.js
@@ -6,6 +6,7 @@ import { prisma } from '../db.js';
 import { requireAdmin } from '../auth.js';
 import { auditFromReq } from '../audit.js';
 import * as powerdns from '../integrations/dns/powerdns.js';
+import { redactForDemo } from '../demo-guard.js';
 
 const PROVIDERS = { powerdns };
 
@@ -19,18 +20,18 @@ const SAFE_FIELDS = [
   'intervalMinutes',
 ];
 
-function maskSecret(s) {
-  if (!s) return s;
-  return '••••••••' + String(s).slice(-4);
-}
+// Placeholder fixo — NUNCA revelar parte do segredo. O front usa hasApiKey.
+const MASK = '••••••••';
 
 function safeView(cfg) {
   if (!cfg) return cfg;
-  return {
+  const view = {
     ...cfg,
-    apiKey: cfg.apiKey ? maskSecret(cfg.apiKey) : null,
+    apiKey: cfg.apiKey ? MASK : null,
     hasApiKey: !!cfg.apiKey,
   };
+  // Na demo, o "admin" é anônimo: não vazar a URL interna do servidor DNS.
+  return redactForDemo(view, ['baseUrl']);
 }
 
 async function getCfg() {

--- a/apps/api/src/routes/ldap.js
+++ b/apps/api/src/routes/ldap.js
@@ -6,12 +6,18 @@ import { prisma } from '../db.js';
 import { requireAdmin } from '../auth.js';
 import { auditFromReq } from '../audit.js';
 import { getConfig, isConfigured, testConnection } from '../auth-providers/ldap.js';
+import { redactForDemo } from '../demo-guard.js';
 
 // Nunca devolve a senha do service account crua pra UI.
+// Na demo, o "admin" é um visitante anônimo: também oculta a topologia interna
+// (url do diretório, DN do service account, baseDn) — só vaza atributos genéricos.
 function maskSecret(cfg) {
   if (!cfg) return cfg;
   const { bindPassword, ...rest } = cfg;
-  return { ...rest, hasBindPassword: !!bindPassword };
+  return redactForDemo(
+    { ...rest, hasBindPassword: !!bindPassword },
+    ['url', 'bindDn', 'baseDn'],
+  );
 }
 
 export async function registerLdapRoutes(app) {

--- a/apps/api/src/routes/oidc.js
+++ b/apps/api/src/routes/oidc.js
@@ -4,7 +4,7 @@
 import { prisma } from '../db.js';
 import { requireAdmin } from '../auth.js';
 import { audit, auditFromReq } from '../audit.js';
-import { DEMO } from '../demo-guard.js';
+import { DEMO, redactForDemo } from '../demo-guard.js';
 import {
   getConfig,
   isConfigured,
@@ -20,11 +20,14 @@ const FLOW_COOKIE = 'bagre_sso_flow';
 
 function maskSecret(cfg) {
   if (!cfg) return cfg;
-  return {
+  const view = {
     ...cfg,
-    clientSecret: cfg.clientSecret ? '••••••••' + cfg.clientSecret.slice(-4) : null,
+    // Placeholder fixo — NUNCA revelar parte do segredo (nem o sufixo).
+    clientSecret: cfg.clientSecret ? '••••••••' : null,
     hasClientSecret: !!cfg.clientSecret,
   };
+  // Na demo, o "admin" é anônimo: não vazar issuer/clientId do IdP.
+  return redactForDemo(view, ['issuer', 'clientId']);
 }
 
 export async function registerOidcRoutes(app) {

--- a/apps/api/src/routes/prometheus.js
+++ b/apps/api/src/routes/prometheus.js
@@ -6,6 +6,7 @@ import {
   testConnection,
   syncFromPrometheus,
 } from '../integrations/prometheus.js';
+import { redactForDemo } from '../demo-guard.js';
 
 const SAFE_FIELDS = [
   'enabled',
@@ -19,20 +20,20 @@ const SAFE_FIELDS = [
   'staleAfterDays',
 ];
 
-function maskSecret(s) {
-  if (!s) return s;
-  return '••••••••' + String(s).slice(-4);
-}
+// Placeholder fixo — NUNCA revelar parte do segredo. O front usa hasBearerToken/hasBasicPassword.
+const MASK = '••••••••';
 
 function safeView(cfg) {
   if (!cfg) return cfg;
-  return {
+  const view = {
     ...cfg,
-    bearerToken: cfg.bearerToken ? maskSecret(cfg.bearerToken) : null,
-    basicPassword: cfg.basicPassword ? maskSecret(cfg.basicPassword) : null,
+    bearerToken: cfg.bearerToken ? MASK : null,
+    basicPassword: cfg.basicPassword ? MASK : null,
     hasBearerToken: !!cfg.bearerToken,
     hasBasicPassword: !!cfg.basicPassword,
   };
+  // Na demo, o "admin" é anônimo: não vazar host/usuário internos.
+  return redactForDemo(view, ['url', 'basicUsername']);
 }
 
 export async function registerPrometheusRoutes(app) {

--- a/apps/api/src/routes/zabbix.js
+++ b/apps/api/src/routes/zabbix.js
@@ -7,7 +7,7 @@ import {
   syncFromZabbix,
   invalidateSession,
 } from '../integrations/zabbix.js';
-import { stripDemoPinned } from '../demo-guard.js';
+import { stripDemoPinned, redactForDemo } from '../demo-guard.js';
 
 const SAFE_FIELDS = [
   'enabled',
@@ -20,20 +20,21 @@ const SAFE_FIELDS = [
   'staleAfterDays',
 ];
 
-function maskSecret(s) {
-  if (!s) return s;
-  return '••••••••' + String(s).slice(-4);
-}
+// Placeholder fixo — NUNCA revelar parte do segredo (nem o sufixo). O front
+// usa hasApiToken/hasPassword pra saber se há valor configurado.
+const MASK = '••••••••';
 
 function safeView(cfg) {
   if (!cfg) return cfg;
-  return {
+  const view = {
     ...cfg,
-    apiToken: cfg.apiToken ? maskSecret(cfg.apiToken) : null,
-    password: cfg.password ? maskSecret(cfg.password) : null,
+    apiToken: cfg.apiToken ? MASK : null,
+    password: cfg.password ? MASK : null,
     hasApiToken: !!cfg.apiToken,
     hasPassword: !!cfg.password,
   };
+  // Na demo, o "admin" é anônimo: não vazar host/usuário internos.
+  return redactForDemo(view, ['url', 'username']);
 }
 
 export async function registerZabbixRoutes(app) {

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -14,6 +14,9 @@ services:
   api:
     environment:
       DEMO_MODE: "true"
+      # Login é o ÚNICO write exposto na demo → teto de brute-force bem apertado
+      # (12 tentativas / 5min / IP). Em produção o default é 30 (NAT-friendly).
+      LOGIN_RATE_MAX: "12"
       DEMO_ADMIN_EMAIL: ${DEMO_ADMIN_EMAIL:-demo-admin@bagre.dev}
       DEMO_ADMIN_PASSWORD: ${DEMO_ADMIN_PASSWORD:-demo-admin}
       DEMO_READER_EMAIL: ${DEMO_READER_EMAIL:-demo-reader@bagre.dev}


### PR DESCRIPTION
## Contexto
Auditoria do que um visitante do demo público consegue ver logando como **ADMIN** (via `alice` no AD/LDAP). Demo = "admin" é um visitante anônimo da internet, então tudo que um admin lê precisa ser seguro.

## Problemas encontrados
1. **Vazamento parcial de segredo (prod + demo):** `maskSecret` devolvia os últimos 4 chars de todo segredo — `'••••••••' + slice(-4)`. Ex.: senha do Zabbix aparecia como `••••••••bbix` → "zabbix". Afeta `zabbix`, `dns`, `prometheus`, `oidc`.
2. **Vazamento de topologia interna na demo:** os GETs de config admin expunham `ldap://openldap:389`, `cn=admin,dc=corp,dc=local`, hosts de Zabbix/Prometheus pro visitante anônimo.

## Correções
- `maskSecret` agora usa placeholder fixo `'••••••••'` (+ flags `hasX`). Round-trip do PATCH continua funcionando (checa `startsWith('••••')`).
- Novo helper `redactForDemo(obj, fields)` em `demo-guard.js`: **só na demo**, oculta `url`/`host`/`bindDn`/`baseDn`/`username`. Self-host não é afetado.
- Rate-limit de login agora é configurável via `LOGIN_RATE_MAX` (default prod **30**, NAT-friendly; demo fixa **12** — login é o único write exposto na demo).

## Teste
- `node --check` em todos os arquivos alterados ✅
- Audit reproduzido contra o demo live (alice→admin) antes do fix.
