### PR TITLE
fix(demo): ambiente público 100% somente-leitura na UI (trava central + botões escondidos)

### DIFF
--- a/apps/web/src/api.js
+++ b/apps/web/src/api.js
@@ -12,7 +12,29 @@ export function setUnauthorizedHandler(fn) {
   onUnauthorized = fn;
 }
 
+// Trava de demonstração (somente-leitura). Ligada pelo Layout quando
+// /api/config diz demo.enabled. Defesa em profundidade: a API já bloqueia toda
+// escrita no DEMO_MODE; aqui barramos no cliente ANTES de enviar, pra nenhum
+// botão (atual ou futuro) conseguir apagar/alterar nada — e avisamos o usuário.
+let demoMode = false;
+export function setDemoMode(v) {
+  demoMode = !!v;
+}
+let onDemoBlock = () => {};
+export function setDemoBlockHandler(fn) {
+  onDemoBlock = fn;
+}
+const WRITE_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
 async function request(path, opts = {}) {
+  const method = (opts.method || 'GET').toUpperCase();
+  // Login é o único write permitido na demo (é como o visitante entra).
+  if (demoMode && WRITE_METHODS.has(method) && path !== '/auth/login') {
+    onDemoBlock();
+    const err = new Error('Ambiente de demonstração: somente leitura.');
+    err.demoBlocked = true;
+    throw err;
+  }
   const headers = { ...(opts.headers || {}) };
   // Only set JSON content-type when there's actually a body to send.
   // Fastify rejects requests with content-type set but empty body.

--- a/apps/web/src/components/Layout.jsx
+++ b/apps/web/src/components/Layout.jsx
@@ -27,7 +27,8 @@ import { useEffect, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import GlobalSearch from './GlobalSearch.jsx';
 import { useAuth } from '../auth/AuthContext.jsx';
-import { api } from '../api.js';
+import { api, setDemoMode, setDemoBlockHandler } from '../api.js';
+import { useToast } from './Toast.jsx';
 
 const NAV_BASE = [
   { to: '/', label: 'Dashboard', icon: LayoutDashboard, end: true },
@@ -101,6 +102,20 @@ export default function Layout({ children }) {
   });
   const demoBanner = cfg?.demo?.enabled ? cfg.demo.banner : null;
   const isDemo = !!cfg?.demo?.enabled;
+  const toast = useToast();
+
+  // Liga a trava de escrita do cliente no modo demo + avisa ao tentar escrever.
+  useEffect(() => {
+    setDemoMode(isDemo);
+  }, [isDemo]);
+  useEffect(() => {
+    setDemoBlockHandler(() =>
+      toast.info('Ambiente de demonstração — somente leitura. Nada é alterado aqui.', {
+        title: 'Ação desabilitada',
+      }),
+    );
+    return () => setDemoBlockHandler(() => {});
+  }, [toast]);
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');

--- a/apps/web/src/pages/Catalogs.jsx
+++ b/apps/web/src/pages/Catalogs.jsx
@@ -31,7 +31,16 @@ const DATACENTER_FIELDS = [
 export default function Catalogs() {
   const [tab, setTab] = useState('master');
   const { user } = useAuth();
-  const canEdit = user?.role === 'ADMIN';
+  // No ambiente de demonstração tudo é somente-leitura (a API bloqueia toda
+  // escrita). Escondemos as ações de gestão (criar/editar/excluir) pra não
+  // confundir nem passar impressão de insegurança.
+  const { data: appCfg } = useQuery({
+    queryKey: ['app-config'],
+    queryFn: api.config,
+    staleTime: 60_000,
+  });
+  const demo = !!appCfg?.demo?.enabled;
+  const canEdit = user?.role === 'ADMIN' && !demo;
 
   // Dynamic tabs: one per connected cloud account. Refetch periodically so
   // newly added accounts surface here without a page reload.
@@ -77,8 +86,8 @@ export default function Catalogs() {
         ))}
       </div>
 
-      {tab === 'master' && <MasterRanges canEdit={canEdit} />}
-      {tab === 'datacenter' && <DatacenterVlans canEdit={canEdit} />}
+      {tab === 'master' && <MasterRanges canEdit={canEdit} demo={demo} />}
+      {tab === 'datacenter' && <DatacenterVlans canEdit={canEdit} demo={demo} />}
       {tab.startsWith('cloud-') && (
         <CloudAccountSubnets
           accountId={cloudTabs.find((t) => t.id === tab)?.accountId}
@@ -208,7 +217,14 @@ function Toolbar({ canEdit, onNew, label }) {
   );
 }
 
-function ActionCell({ canEdit, onEdit, onDelete }) {
+function ActionCell({ canEdit, demo, onEdit, onDelete }) {
+  if (demo) {
+    return (
+      <td className="px-3 py-1.5 text-right whitespace-nowrap">
+        <span className="text-xs text-slate-400 italic">somente leitura</span>
+      </td>
+    );
+  }
   if (!canEdit) return null;
   return (
     <td className="px-3 py-1.5 text-right whitespace-nowrap">
@@ -230,7 +246,7 @@ function ActionCell({ canEdit, onEdit, onDelete }) {
   );
 }
 
-function MasterRanges({ canEdit }) {
+function MasterRanges({ canEdit, demo }) {
   const crud = useCrud({
     key: 'master-ranges',
     list: api.masterRanges,
@@ -252,7 +268,7 @@ function MasterRanges({ canEdit }) {
               <th className="px-3 py-2 text-left">CIDR</th>
               <th className="px-3 py-2 text-left">Descrição</th>
               <th className="px-3 py-2 text-left">Categoria</th>
-              {canEdit && <th className="px-3 py-2 w-20" />}
+              {(canEdit || demo) && <th className="px-3 py-2 w-20" />}
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
@@ -263,6 +279,7 @@ function MasterRanges({ canEdit }) {
                 <td className="px-3 py-1.5 text-slate-500">{r.category || '—'}</td>
                 <ActionCell
                   canEdit={canEdit}
+                  demo={demo}
                   onEdit={() => { setErr(null); setModal({ open: true, initial: r }); }}
                   onDelete={() => setConfirm({ open: true, id: r.id, label: r.cidr })}
                 />
@@ -307,7 +324,7 @@ function MasterRanges({ canEdit }) {
   );
 }
 
-function DatacenterVlans({ canEdit }) {
+function DatacenterVlans({ canEdit, demo }) {
   const crud = useCrud({
     key: 'datacenter-vlans',
     list: api.datacenterVlans,
@@ -332,7 +349,7 @@ function DatacenterVlans({ canEdit }) {
               <th className="px-3 py-2 text-left">Network</th>
               <th className="px-3 py-2 text-left">Range</th>
               <th className="px-3 py-2 text-left">Broadcast</th>
-              {canEdit && <th className="px-3 py-2 w-20" />}
+              {(canEdit || demo) && <th className="px-3 py-2 w-20" />}
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
@@ -346,6 +363,7 @@ function DatacenterVlans({ canEdit }) {
                 <td className="px-3 py-1.5 font-mono text-xs">{r.broadcast || '—'}</td>
                 <ActionCell
                   canEdit={canEdit}
+                  demo={demo}
                   onEdit={() => { setErr(null); setModal({ open: true, initial: r }); }}
                   onDelete={() => setConfirm({ open: true, id: r.id, label: r.name })}
                 />

--- a/apps/web/src/pages/CloudAccounts.jsx
+++ b/apps/web/src/pages/CloudAccounts.jsx
@@ -253,7 +253,7 @@ function IdlePublicIpsTable({ items }) {
   );
 }
 
-function AccountCard({ account, onSync, onTest, onDelete, syncing }) {
+function AccountCard({ account, onSync, onTest, onDelete, syncing, demo }) {
   const [expanded, setExpanded] = useState(false);
   const info = PROVIDER_INFO[account.provider] || PROVIDER_INFO.AWS;
   const { data: runs = [] } = useQuery({
@@ -299,21 +299,25 @@ function AccountCard({ account, onSync, onTest, onDelete, syncing }) {
       )}
 
       <div className="flex items-center gap-2 mt-4">
-        <button
-          onClick={() => onSync(account.id)}
-          disabled={syncing}
-          className="btn-primary text-xs inline-flex items-center gap-1 disabled:opacity-50"
-        >
-          <RefreshCw size={12} className={syncing ? 'animate-spin' : ''} />
-          {syncing ? 'Sincronizando…' : 'Sync agora'}
-        </button>
-        <button
-          onClick={() => onTest(account.id)}
-          className="text-xs px-3 py-1.5 rounded border border-slate-200 hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800 inline-flex items-center gap-1"
-        >
-          <Play size={12} />
-          Test creds
-        </button>
+        {!demo && (
+          <>
+            <button
+              onClick={() => onSync(account.id)}
+              disabled={syncing}
+              className="btn-primary text-xs inline-flex items-center gap-1 disabled:opacity-50"
+            >
+              <RefreshCw size={12} className={syncing ? 'animate-spin' : ''} />
+              {syncing ? 'Sincronizando…' : 'Sync agora'}
+            </button>
+            <button
+              onClick={() => onTest(account.id)}
+              className="text-xs px-3 py-1.5 rounded border border-slate-200 hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800 inline-flex items-center gap-1"
+            >
+              <Play size={12} />
+              Test creds
+            </button>
+          </>
+        )}
         <button
           onClick={() => setExpanded((e) => !e)}
           className="text-xs px-3 py-1.5 rounded hover:bg-slate-100 dark:hover:bg-slate-800 inline-flex items-center gap-1 text-slate-600"
@@ -322,12 +326,16 @@ function AccountCard({ account, onSync, onTest, onDelete, syncing }) {
           Histórico
         </button>
         <div className="flex-1" />
-        <button
-          onClick={() => onDelete(account.id, account.displayName)}
-          className="text-xs px-2 py-1.5 rounded text-rose-600 hover:bg-rose-50 dark:hover:bg-rose-900/30 inline-flex items-center gap-1"
-        >
-          <Trash2 size={12} />
-        </button>
+        {demo ? (
+          <span className="text-xs text-slate-400 italic">somente leitura</span>
+        ) : (
+          <button
+            onClick={() => onDelete(account.id, account.displayName)}
+            className="text-xs px-2 py-1.5 rounded text-rose-600 hover:bg-rose-50 dark:hover:bg-rose-900/30 inline-flex items-center gap-1"
+          >
+            <Trash2 size={12} />
+          </button>
+        )}
       </div>
 
       {expanded && (
@@ -689,6 +697,16 @@ export default function CloudAccounts() {
   const [addOpen, setAddOpen] = useState(false);
   const [syncing, setSyncing] = useState(null);
 
+  // Em modo demonstração tudo é somente-leitura (a API bloqueia toda escrita).
+  // Escondemos as ações de mutação (conectar/sync/test/excluir conta) pra não
+  // confundir nem passar impressão de insegurança.
+  const { data: appCfg } = useQuery({
+    queryKey: ['app-config'],
+    queryFn: api.config,
+    staleTime: 60_000,
+  });
+  const demo = !!appCfg?.demo?.enabled;
+
   const { data: providers } = useQuery({
     queryKey: ['cloud-providers'],
     queryFn: api.cloudProviders,
@@ -744,10 +762,12 @@ export default function CloudAccounts() {
         title="Cloud Accounts"
         description="Conecte AWS / Azure / GCP e o Bagre importa subnets e IPs automaticamente. Use a auditoria abaixo para identificar IPs públicos ociosos e decidir o que pode ser liberado."
         actions={
-          <button onClick={() => setAddOpen(true)} className="btn-primary inline-flex items-center gap-1.5">
-            <Plus size={14} />
-            Conectar conta
-          </button>
+          demo ? null : (
+            <button onClick={() => setAddOpen(true)} className="btn-primary inline-flex items-center gap-1.5">
+              <Plus size={14} />
+              Conectar conta
+            </button>
+          )
         }
       />
 
@@ -761,10 +781,12 @@ export default function CloudAccounts() {
           <p className="text-sm text-slate-500 mb-4 max-w-md mx-auto">
             Conecte sua AWS em menos de 2 minutos. Cria-se um IAM User (ou Role) com permissão read-only, cola credenciais aqui — o Bagre testa e sincroniza na hora.
           </p>
-          <button onClick={() => setAddOpen(true)} className="btn-primary inline-flex items-center gap-1.5">
-            <Plus size={14} />
-            Conectar primeira conta
-          </button>
+          {!demo && (
+            <button onClick={() => setAddOpen(true)} className="btn-primary inline-flex items-center gap-1.5">
+              <Plus size={14} />
+              Conectar primeira conta
+            </button>
+          )}
         </div>
       ) : (
         <div className="grid lg:grid-cols-2 gap-4">
@@ -772,6 +794,7 @@ export default function CloudAccounts() {
             <AccountCard
               key={a.id}
               account={a}
+              demo={demo}
               syncing={syncing === a.id}
               onSync={(id) => syncMut.mutate(id)}
               onTest={(id) => testMut.mutate(id)}

--- a/apps/web/src/pages/Devices.jsx
+++ b/apps/web/src/pages/Devices.jsx
@@ -28,8 +28,22 @@ function formatDate(iso) {
 
 export default function Devices() {
   const { user } = useAuth();
-  const canEdit = user?.role === 'ADMIN';
   const qc = useQueryClient();
+
+  // No ambiente de demonstração tudo é somente-leitura (a API bloqueia toda
+  // escrita). Escondemos as ações de criar/editar/excluir equipamento pra não
+  // confundir nem passar impressão de insegurança.
+  const { data: appCfg } = useQuery({
+    queryKey: ['app-config'],
+    queryFn: api.config,
+    staleTime: 60_000,
+  });
+  const demo = !!appCfg?.demo?.enabled;
+  const isAdmin = user?.role === 'ADMIN';
+  const canEdit = isAdmin && !demo;
+  // Em demo, um ADMIN ainda vê a coluna de ações (mas só "somente leitura"),
+  // para deixar explícito que a gestão existe e está apenas travada.
+  const showActionsCol = isAdmin;
 
   const [q, setQ] = useState('');
   const [siteFilter, setSiteFilter] = useState('');
@@ -155,13 +169,13 @@ export default function Devices() {
               <th className="px-3 py-2.5">IPs</th>
               <th className="px-3 py-2.5">Responsável</th>
               <th className="px-3 py-2.5">Última vez visto</th>
-              {canEdit && <th className="px-3 py-2.5 w-24" />}
+              {showActionsCol && <th className="px-3 py-2.5 w-24" />}
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
             {!isLoading && devices.length === 0 && (
               <tr>
-                <td colSpan={canEdit ? 8 : 7} className="p-8 text-center text-slate-500">
+                <td colSpan={showActionsCol ? 8 : 7} className="p-8 text-center text-slate-500">
                   Nenhum equipamento com esse filtro.
                 </td>
               </tr>
@@ -197,28 +211,34 @@ export default function Devices() {
                   {d.ownerEmail || '—'}
                 </td>
                 <td className="px-3 py-2 text-xs text-slate-500">{formatDate(d.lastSeenAt)}</td>
-                {canEdit && (
+                {showActionsCol && (
                   <td
                     className="px-3 py-2 text-right whitespace-nowrap"
                     onClick={(e) => e.stopPropagation()}
                   >
-                    <button
-                      onClick={() => {
-                        setErr(null);
-                        setModal({ open: true, initial: d });
-                      }}
-                      className="text-slate-400 hover:text-brand-600 p-1 rounded hover:bg-slate-100 dark:hover:bg-slate-800"
-                      title="Editar"
-                    >
-                      <Pencil size={14} />
-                    </button>
-                    <button
-                      onClick={() => setConfirm({ open: true, device: d })}
-                      className="text-slate-400 hover:text-rose-600 p-1 rounded hover:bg-rose-50 dark:hover:bg-rose-900/30 ml-1"
-                      title="Excluir (libera IPs vinculados)"
-                    >
-                      <Trash2 size={14} />
-                    </button>
+                    {demo ? (
+                      <span className="text-xs text-slate-400 italic">somente leitura</span>
+                    ) : (
+                      <>
+                        <button
+                          onClick={() => {
+                            setErr(null);
+                            setModal({ open: true, initial: d });
+                          }}
+                          className="text-slate-400 hover:text-brand-600 p-1 rounded hover:bg-slate-100 dark:hover:bg-slate-800"
+                          title="Editar"
+                        >
+                          <Pencil size={14} />
+                        </button>
+                        <button
+                          onClick={() => setConfirm({ open: true, device: d })}
+                          className="text-slate-400 hover:text-rose-600 p-1 rounded hover:bg-rose-50 dark:hover:bg-rose-900/30 ml-1"
+                          title="Excluir (libera IPs vinculados)"
+                        >
+                          <Trash2 size={14} />
+                        </button>
+                      </>
+                    )}
                   </td>
                 )}
               </tr>

--- a/apps/web/src/pages/DnsSettings.jsx
+++ b/apps/web/src/pages/DnsSettings.jsx
@@ -16,6 +16,14 @@ export default function DnsSettings() {
   const qc = useQueryClient();
   const toast = useToast();
   const { data: cfg, isLoading } = useQuery({ queryKey: ['dns-config'], queryFn: api.dnsConfig });
+  // No ambiente de demonstração tudo é somente-leitura (a API bloqueia toda
+  // escrita). Desabilitamos salvar/testar/preview/sync e os campos do form.
+  const { data: appCfg } = useQuery({
+    queryKey: ['app-config'],
+    queryFn: api.config,
+    staleTime: 60_000,
+  });
+  const demo = !!appCfg?.demo?.enabled;
   const [form, setForm] = useState(null);
 
   useEffect(() => {
@@ -112,16 +120,19 @@ export default function DnsSettings() {
             </div>
           </div>
           <div className="flex flex-col gap-2 shrink-0">
-            <button onClick={() => test.mutate()} disabled={test.isPending || !cfg.baseUrl}
-              className="text-xs px-3 py-1.5 rounded border border-slate-200 hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800 inline-flex items-center gap-1 disabled:opacity-50">
+            <button onClick={() => test.mutate()} disabled={demo || test.isPending || !cfg.baseUrl}
+              title={demo ? 'Desabilitado no ambiente de demonstração' : ''}
+              className="text-xs px-3 py-1.5 rounded border border-slate-200 hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800 inline-flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed">
               <Activity size={12} /> Testar conexão
             </button>
-            <button onClick={() => previewMut.mutate()} disabled={previewMut.isPending || !cfg.defaultZone}
-              className="text-xs px-3 py-1.5 rounded border border-slate-200 hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800 inline-flex items-center gap-1 disabled:opacity-50">
+            <button onClick={() => previewMut.mutate()} disabled={demo || previewMut.isPending || !cfg.defaultZone}
+              title={demo ? 'Desabilitado no ambiente de demonstração' : ''}
+              className="text-xs px-3 py-1.5 rounded border border-slate-200 hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800 inline-flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed">
               <Eye size={12} /> Preview diff
             </button>
-            <button onClick={() => { if (confirm('Aplicar sync no PowerDNS agora?')) sync.mutate(); }} disabled={sync.isPending || !cfg.defaultZone}
-              className="btn-primary text-xs inline-flex items-center gap-1 disabled:opacity-50">
+            <button onClick={() => { if (confirm('Aplicar sync no PowerDNS agora?')) sync.mutate(); }} disabled={demo || sync.isPending || !cfg.defaultZone}
+              title={demo ? 'Desabilitado no ambiente de demonstração' : ''}
+              className="btn-primary text-xs inline-flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed">
               <RefreshCcw size={12} className={sync.isPending ? 'animate-spin' : ''} />
               {sync.isPending ? 'Sincronizando…' : 'Sync agora'}
             </button>
@@ -157,8 +168,8 @@ export default function DnsSettings() {
           <label className="text-xs font-medium text-slate-600 block mb-1.5">Provider DNS</label>
           <div className="grid grid-cols-2 gap-2">
             {PROVIDERS.map((p) => (
-              <button key={p.id} type="button" onClick={() => p.impl && update('provider', p.id)}
-                className={`text-left px-3 py-2 rounded border text-sm transition ${
+              <button key={p.id} type="button" disabled={demo} onClick={() => p.impl && update('provider', p.id)}
+                className={`text-left px-3 py-2 rounded border text-sm transition disabled:opacity-60 disabled:cursor-not-allowed ${
                   form.provider === p.id
                     ? 'border-brand-500 bg-brand-50 dark:bg-brand-900/30'
                     : 'border-slate-200 hover:border-slate-300'
@@ -172,38 +183,43 @@ export default function DnsSettings() {
 
         <div>
           <label className="text-xs font-medium text-slate-600 block mb-1">URL da API</label>
-          <input className="input w-full font-mono text-sm" placeholder="https://powerdns.empresa.local:8081/api/v1" value={form.baseUrl} onChange={(e) => update('baseUrl', e.target.value)} />
+          <input disabled={demo} className="input w-full font-mono text-sm disabled:opacity-60 disabled:cursor-not-allowed" placeholder="https://powerdns.empresa.local:8081/api/v1" value={form.baseUrl} onChange={(e) => update('baseUrl', e.target.value)} />
         </div>
 
         <div>
           <label className="text-xs font-medium text-slate-600 block mb-1">API Key (X-API-Key)</label>
-          <input type="password" className="input w-full font-mono text-sm" placeholder={cfg.hasApiKey ? '(salva — deixe vazio pra manter)' : '••••••••'} value={form.apiKey} onChange={(e) => update('apiKey', e.target.value)} />
+          <input type="password" disabled={demo} className="input w-full font-mono text-sm disabled:opacity-60 disabled:cursor-not-allowed" placeholder={cfg.hasApiKey ? '(salva — deixe vazio pra manter)' : '••••••••'} value={form.apiKey} onChange={(e) => update('apiKey', e.target.value)} />
         </div>
 
         <div className="grid grid-cols-2 gap-3">
           <div>
             <label className="text-xs font-medium text-slate-600 block mb-1">Server ID</label>
-            <input className="input w-full font-mono text-sm" placeholder="localhost" value={form.serverId} onChange={(e) => update('serverId', e.target.value)} />
+            <input disabled={demo} className="input w-full font-mono text-sm disabled:opacity-60 disabled:cursor-not-allowed" placeholder="localhost" value={form.serverId} onChange={(e) => update('serverId', e.target.value)} />
           </div>
           <div>
             <label className="text-xs font-medium text-slate-600 block mb-1">Intervalo (min)</label>
-            <input type="number" min="5" className="input w-full text-sm" value={form.intervalMinutes} onChange={(e) => update('intervalMinutes', Number(e.target.value))} />
+            <input type="number" min="5" disabled={demo} className="input w-full text-sm disabled:opacity-60 disabled:cursor-not-allowed" value={form.intervalMinutes} onChange={(e) => update('intervalMinutes', Number(e.target.value))} />
           </div>
         </div>
 
         <div>
           <label className="text-xs font-medium text-slate-600 block mb-1">Zona padrão</label>
-          <input className="input w-full font-mono text-sm" placeholder="internal.empresa.local." value={form.defaultZone} onChange={(e) => update('defaultZone', e.target.value)} />
+          <input disabled={demo} className="input w-full font-mono text-sm disabled:opacity-60 disabled:cursor-not-allowed" placeholder="internal.empresa.local." value={form.defaultZone} onChange={(e) => update('defaultZone', e.target.value)} />
           <p className="text-[11px] text-slate-500 mt-1">Pode incluir o ponto final (padrão PowerDNS). Os hostnames do Bagre vão virar <code>&lt;hostname&gt;.&lt;zona&gt;</code>.</p>
         </div>
 
         <label className="flex items-center gap-2 cursor-pointer">
-          <input type="checkbox" checked={form.enabled} onChange={(e) => update('enabled', e.target.checked)} className="accent-brand-600" />
+          <input type="checkbox" disabled={demo} checked={form.enabled} onChange={(e) => update('enabled', e.target.checked)} className="accent-brand-600 disabled:opacity-60 disabled:cursor-not-allowed" />
           <span className="text-sm">Sync automático ativo</span>
         </label>
 
         <div className="flex items-center justify-end gap-2 pt-2 border-t border-slate-100 dark:border-slate-800">
-          <button type="submit" disabled={save.isPending} className="btn-primary inline-flex items-center gap-1 disabled:opacity-50">
+          {demo && (
+            <p className="text-xs text-slate-400 mr-auto">
+              Configuração somente leitura no ambiente de demonstração.
+            </p>
+          )}
+          <button type="submit" disabled={demo || save.isPending} title={demo ? 'Desabilitado no ambiente de demonstração' : ''} className="btn-primary inline-flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed">
             <Save size={14} /> {save.isPending ? 'Salvando…' : 'Salvar'}
           </button>
         </div>

--- a/apps/web/src/pages/PendingDiscoveries.jsx
+++ b/apps/web/src/pages/PendingDiscoveries.jsx
@@ -47,8 +47,18 @@ function formatDate(iso) {
 
 export default function PendingDiscoveries() {
   const { user } = useAuth();
-  const canEdit = user?.role === 'ADMIN';
   const qc = useQueryClient();
+
+  // No ambiente de demonstração tudo é somente-leitura (a API bloqueia toda
+  // escrita, incluindo aprovar/rejeitar/bulk). Escondemos todas as ações
+  // mutantes — a lista de descobertas continua visível pra mostrar os hosts.
+  const { data: appCfg } = useQuery({
+    queryKey: ['app-config'],
+    queryFn: api.config,
+    staleTime: 60_000,
+  });
+  const demo = !!appCfg?.demo?.enabled;
+  const canEdit = user?.role === 'ADMIN' && !demo;
 
   const [status, setStatus] = useState('PENDING');
   const [q, setQ] = useState('');
@@ -272,6 +282,7 @@ export default function PendingDiscoveries() {
               <DiscoveryTable
                 rows={group}
                 canEdit={canEdit}
+                demo={demo}
                 selected={selected}
                 onToggle={toggleSelect}
                 onApprove={(d) => {
@@ -299,6 +310,7 @@ export default function PendingDiscoveries() {
             <DiscoveryTable
               rows={discoveries}
               canEdit={false}
+              demo={demo}
               showStatusInfo
             />
           )}
@@ -359,7 +371,7 @@ export default function PendingDiscoveries() {
   );
 }
 
-function DiscoveryTable({ rows, canEdit, selected, onToggle, onApprove, onReject, showStatusInfo }) {
+function DiscoveryTable({ rows, canEdit, demo, selected, onToggle, onApprove, onReject, showStatusInfo }) {
   return (
     <table className="w-full text-sm">
       <thead className="bg-slate-50 dark:bg-slate-800/30 text-left text-xs uppercase tracking-wider text-slate-500">
@@ -373,7 +385,7 @@ function DiscoveryTable({ rows, canEdit, selected, onToggle, onApprove, onReject
           <th className="px-3 py-2">Visto há</th>
           <th className="px-3 py-2 w-14">Vezes</th>
           {showStatusInfo && <th className="px-3 py-2">Decidido por</th>}
-          {canEdit && <th className="px-3 py-2 w-32 text-right">Ações</th>}
+          {(canEdit || demo) && <th className="px-3 py-2 w-32 text-right">Ações</th>}
         </tr>
       </thead>
       <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
@@ -434,6 +446,11 @@ function DiscoveryTable({ rows, canEdit, selected, onToggle, onApprove, onReject
                 >
                   <X size={12} />
                 </button>
+              </td>
+            )}
+            {!canEdit && demo && (
+              <td className="px-3 py-2 text-right whitespace-nowrap">
+                <span className="text-xs text-slate-400 italic">somente leitura</span>
               </td>
             )}
           </tr>

--- a/apps/web/src/pages/PrometheusSettings.jsx
+++ b/apps/web/src/pages/PrometheusSettings.jsx
@@ -20,6 +20,14 @@ export default function PrometheusSettings() {
     queryKey: ['prometheus-config'],
     queryFn: api.prometheusConfig,
   });
+  // No ambiente de demonstração tudo é somente-leitura (a API bloqueia toda
+  // escrita). Desabilitamos salvar/testar/sincronizar e os campos do form.
+  const { data: appCfg } = useQuery({
+    queryKey: ['app-config'],
+    queryFn: api.config,
+    staleTime: 60_000,
+  });
+  const demo = !!appCfg?.demo?.enabled;
   const [form, setForm] = useState(null);
   const [jobsCsv, setJobsCsv] = useState('');
 
@@ -135,15 +143,17 @@ export default function PrometheusSettings() {
           <div className="flex flex-col gap-2 shrink-0">
             <button
               onClick={() => test.mutate()}
-              disabled={test.isPending || !cfg.url}
-              className="text-xs px-3 py-1.5 rounded border border-slate-200 hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800 inline-flex items-center gap-1 disabled:opacity-50"
+              disabled={demo || test.isPending || !cfg.url}
+              title={demo ? 'Desabilitado no ambiente de demonstração' : ''}
+              className="text-xs px-3 py-1.5 rounded border border-slate-200 hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800 inline-flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <Activity size={12} /> Testar conexão
             </button>
             <button
               onClick={() => sync.mutate()}
-              disabled={sync.isPending || !cfg.url}
-              className="btn-primary text-xs inline-flex items-center gap-1 disabled:opacity-50"
+              disabled={demo || sync.isPending || !cfg.url}
+              title={demo ? 'Desabilitado no ambiente de demonstração' : ''}
+              className="btn-primary text-xs inline-flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <RefreshCcw size={12} className={sync.isPending ? 'animate-spin' : ''} />
               {sync.isPending ? 'Sincronizando…' : 'Sincronizar agora'}
@@ -156,7 +166,8 @@ export default function PrometheusSettings() {
         <div>
           <label className="text-xs font-medium text-slate-600 block mb-1">URL do Prometheus</label>
           <input
-            className="input w-full font-mono text-sm"
+            disabled={demo}
+            className="input w-full font-mono text-sm disabled:opacity-60 disabled:cursor-not-allowed"
             placeholder="http://prometheus.empresa.local:9090"
             value={form.url}
             onChange={(e) => update('url', e.target.value)}
@@ -174,8 +185,9 @@ export default function PrometheusSettings() {
               <button
                 type="button"
                 key={opt.id}
+                disabled={demo}
                 onClick={() => update('authType', opt.id)}
-                className={`text-left px-3 py-2 rounded border text-sm transition ${
+                className={`text-left px-3 py-2 rounded border text-sm transition disabled:opacity-60 disabled:cursor-not-allowed ${
                   form.authType === opt.id
                     ? 'border-brand-500 bg-brand-50 dark:bg-brand-900/30'
                     : 'border-slate-200 hover:border-slate-300'
@@ -192,7 +204,8 @@ export default function PrometheusSettings() {
               <label className="text-xs font-medium text-slate-600 block mb-1">Bearer token</label>
               <input
                 type="password"
-                className="input w-full font-mono text-sm"
+                disabled={demo}
+                className="input w-full font-mono text-sm disabled:opacity-60 disabled:cursor-not-allowed"
                 placeholder={cfg.hasBearerToken ? '(salvo — deixe vazio pra manter)' : '••••••••'}
                 value={form.bearerToken}
                 onChange={(e) => update('bearerToken', e.target.value)}
@@ -205,7 +218,8 @@ export default function PrometheusSettings() {
               <div>
                 <label className="text-xs font-medium text-slate-600 block mb-1">Usuário</label>
                 <input
-                  className="input w-full text-sm"
+                  disabled={demo}
+                  className="input w-full text-sm disabled:opacity-60 disabled:cursor-not-allowed"
                   value={form.basicUsername}
                   onChange={(e) => update('basicUsername', e.target.value)}
                 />
@@ -214,7 +228,8 @@ export default function PrometheusSettings() {
                 <label className="text-xs font-medium text-slate-600 block mb-1">Senha</label>
                 <input
                   type="password"
-                  className="input w-full text-sm"
+                  disabled={demo}
+                  className="input w-full text-sm disabled:opacity-60 disabled:cursor-not-allowed"
                   placeholder={cfg.hasBasicPassword ? '(salva — deixe vazio pra manter)' : '••••••••'}
                   value={form.basicPassword}
                   onChange={(e) => update('basicPassword', e.target.value)}
@@ -229,7 +244,8 @@ export default function PrometheusSettings() {
             Filtro de jobs (CSV, vazio = todos)
           </label>
           <input
-            className="input w-full text-sm"
+            disabled={demo}
+            className="input w-full text-sm disabled:opacity-60 disabled:cursor-not-allowed"
             placeholder="ex: node, kubernetes, snmp"
             value={jobsCsv}
             onChange={(e) => setJobsCsv(e.target.value)}
@@ -242,7 +258,8 @@ export default function PrometheusSettings() {
             <input
               type="number"
               min="1"
-              className="input w-full text-sm"
+              disabled={demo}
+              className="input w-full text-sm disabled:opacity-60 disabled:cursor-not-allowed"
               value={form.intervalMinutes}
               onChange={(e) => update('intervalMinutes', Number(e.target.value))}
             />
@@ -252,7 +269,8 @@ export default function PrometheusSettings() {
             <input
               type="number"
               min="1"
-              className="input w-full text-sm"
+              disabled={demo}
+              className="input w-full text-sm disabled:opacity-60 disabled:cursor-not-allowed"
               value={form.staleAfterDays}
               onChange={(e) => update('staleAfterDays', Number(e.target.value))}
             />
@@ -262,18 +280,25 @@ export default function PrometheusSettings() {
         <label className="flex items-center gap-2 cursor-pointer">
           <input
             type="checkbox"
+            disabled={demo}
             checked={form.enabled}
             onChange={(e) => update('enabled', e.target.checked)}
-            className="accent-brand-600"
+            className="accent-brand-600 disabled:opacity-60 disabled:cursor-not-allowed"
           />
           <span className="text-sm">Sync automático ativo (roda a cada {form.intervalMinutes} min)</span>
         </label>
 
         <div className="flex items-center justify-end gap-2 pt-2 border-t border-slate-100 dark:border-slate-800">
+          {demo && (
+            <p className="text-xs text-slate-400 mr-auto">
+              Configuração somente leitura no ambiente de demonstração.
+            </p>
+          )}
           <button
             type="submit"
-            disabled={save.isPending}
-            className="btn-primary inline-flex items-center gap-1 disabled:opacity-50"
+            disabled={demo || save.isPending}
+            title={demo ? 'Desabilitado no ambiente de demonstração' : ''}
+            className="btn-primary inline-flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <Save size={14} />
             {save.isPending ? 'Salvando…' : 'Salvar'}

--- a/apps/web/src/pages/Sites.jsx
+++ b/apps/web/src/pages/Sites.jsx
@@ -78,6 +78,16 @@ export default function Sites() {
     queryKey: ['sites'],
     queryFn: api.sites,
   });
+  // No ambiente de demonstração tudo é somente-leitura (a API bloqueia toda
+  // escrita). Escondemos as ações de criar/editar/excluir site e subnet pra não
+  // confundir nem passar impressão de insegurança.
+  const { data: appCfg } = useQuery({
+    queryKey: ['app-config'],
+    queryFn: api.config,
+    staleTime: 60_000,
+  });
+  const demo = !!appCfg?.demo?.enabled;
+  const canWrite = canEdit && !demo;
   const [q, setQ] = useState('');
 
   const [siteModal, setSiteModal] = useState({ open: false, initial: null });
@@ -183,7 +193,7 @@ export default function Sites() {
         title="Sites & Subnets"
         description="Cada site é uma localização (data center, escritório). Dentro dele ficam as subnets — clique em uma para ver e editar os IPs."
         actions={
-          canEdit && (
+          canWrite && (
             <button
               onClick={() => {
                 setFormError(null);
@@ -231,7 +241,7 @@ export default function Sites() {
                       <div className="text-xs text-slate-500 truncate">{site.name}</div>
                     )}
                   </div>
-                  {canEdit && (
+                  {canWrite && (
                     <ActionMenu
                       items={[
                         {
@@ -316,7 +326,7 @@ export default function Sites() {
                             className="text-slate-300 group-hover:text-brand-500 transition shrink-0"
                           />
                         </Link>
-                        {canEdit && (
+                        {canWrite && (
                           <ActionMenu
                             items={[
                               {
@@ -351,7 +361,7 @@ export default function Sites() {
                       </div>
                     );
                   })}
-                  {canEdit && site.subnets.length === 0 && (
+                  {canWrite && site.subnets.length === 0 && (
                     <button
                       onClick={() => {
                         setFormError(null);

--- a/apps/web/src/pages/SsoSettings.jsx
+++ b/apps/web/src/pages/SsoSettings.jsx
@@ -70,6 +70,14 @@ export default function SsoSettings() {
     queryKey: ['oidc-config'],
     queryFn: api.oidcConfig,
   });
+  // No ambiente de demonstração tudo é somente-leitura (a API bloqueia toda
+  // escrita). Desabilitamos salvar/testar/habilitar e os campos do form.
+  const { data: appCfg } = useQuery({
+    queryKey: ['app-config'],
+    queryFn: api.config,
+    staleTime: 60_000,
+  });
+  const demo = !!appCfg?.demo?.enabled;
   const [form, setForm] = useState(null);
   const [groupsCsv, setGroupsCsv] = useState('');
   const [provider, setProvider] = useState('microsoft');
@@ -180,9 +188,15 @@ export default function SsoSettings() {
         actions={
           <button
             onClick={() => enable.mutate()}
-            disabled={!fullyConfigured || enable.isPending}
-            className={form.enabled ? 'btn-danger' : 'btn-primary'}
-            title={!fullyConfigured ? 'Configure tudo antes de habilitar' : ''}
+            disabled={demo || !fullyConfigured || enable.isPending}
+            className={`${form.enabled ? 'btn-danger' : 'btn-primary'} disabled:opacity-50 disabled:cursor-not-allowed`}
+            title={
+              demo
+                ? 'Desabilitado no ambiente de demonstração'
+                : !fullyConfigured
+                ? 'Configure tudo antes de habilitar'
+                : ''
+            }
           >
             <Power size={14} />
             {form.enabled ? 'Desabilitar SSO' : 'Habilitar SSO'}
@@ -203,8 +217,9 @@ export default function SsoSettings() {
             <button
               key={key}
               type="button"
+              disabled={demo}
               onClick={() => applyPreset(key)}
-              className={`text-sm px-3 py-1.5 rounded-lg border transition ${
+              className={`text-sm px-3 py-1.5 rounded-lg border transition disabled:opacity-60 disabled:cursor-not-allowed ${
                 provider === key
                   ? 'border-brand-500 bg-brand-50 dark:bg-brand-900/20 text-brand-700 dark:text-brand-300 font-medium'
                   : 'border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800'
@@ -238,9 +253,10 @@ export default function SsoSettings() {
           <Field label={`Redirect URI (cole esta no ${prov.label})`}>
             <CopyInput value={form.redirectUri} />
             <input
+              disabled={demo}
               value={form.redirectUri}
               onChange={(e) => setForm({ ...form, redirectUri: e.target.value })}
-              className="input mt-2 font-mono text-xs"
+              className="input mt-2 font-mono text-xs disabled:opacity-60 disabled:cursor-not-allowed"
             />
           </Field>
         </Section>
@@ -249,20 +265,22 @@ export default function SsoSettings() {
           <Field label="Issuer URL" hint={prov.issuerHint}>
             <input
               required
+              disabled={demo}
               value={form.issuerUrl}
               onChange={(e) => setForm({ ...form, issuerUrl: e.target.value })}
               placeholder={prov.issuerPlaceholder}
               readOnly={Boolean(prov.issuerFixed)}
-              className={`input font-mono text-xs ${prov.issuerFixed ? 'bg-slate-50 dark:bg-slate-800/50' : ''}`}
+              className={`input font-mono text-xs disabled:opacity-60 disabled:cursor-not-allowed ${prov.issuerFixed ? 'bg-slate-50 dark:bg-slate-800/50' : ''}`}
             />
           </Field>
           <Field label="Application (client) ID">
             <input
               required
+              disabled={demo}
               value={form.clientId}
               onChange={(e) => setForm({ ...form, clientId: e.target.value })}
               placeholder="00000000-0000-0000-0000-000000000000"
-              className="input font-mono text-xs"
+              className="input font-mono text-xs disabled:opacity-60 disabled:cursor-not-allowed"
             />
           </Field>
           <Field
@@ -275,10 +293,11 @@ export default function SsoSettings() {
           >
             <input
               type="password"
+              disabled={demo}
               value={form.clientSecret}
               onChange={(e) => setForm({ ...form, clientSecret: e.target.value })}
               placeholder={cfg?.hasClientSecret ? '•••••••• (mantém o atual)' : ''}
-              className="input"
+              className="input disabled:opacity-60 disabled:cursor-not-allowed"
             />
           </Field>
         </Section>
@@ -289,18 +308,20 @@ export default function SsoSettings() {
             hint="Object IDs dos grupos no Entra ID, separados por vírgula. Usuário em qualquer um deles vira ADMIN. Se vazio, ninguém é promovido automaticamente — defina o papel manualmente."
           >
             <input
+              disabled={demo}
               value={groupsCsv}
               onChange={(e) => setGroupsCsv(e.target.value)}
               placeholder="aaaaaaaa-..., bbbbbbbb-..."
-              className="input font-mono text-xs"
+              className="input font-mono text-xs disabled:opacity-60 disabled:cursor-not-allowed"
             />
           </Field>
           <div className="grid grid-cols-2 gap-3">
             <Field label="Perfil padrão para novos usuários">
               <select
+                disabled={demo}
                 value={form.defaultRole}
                 onChange={(e) => setForm({ ...form, defaultRole: e.target.value })}
-                className="input"
+                className="input disabled:opacity-60 disabled:cursor-not-allowed"
               >
                 <option value="READER">READER (somente leitura)</option>
                 <option value="ADMIN">ADMIN</option>
@@ -310,11 +331,12 @@ export default function SsoSettings() {
               <label className="inline-flex items-center gap-2 text-sm pt-2">
                 <input
                   type="checkbox"
+                  disabled={demo}
                   checked={form.autoProvision}
                   onChange={(e) =>
                     setForm({ ...form, autoProvision: e.target.checked })
                   }
-                  className="accent-brand-600"
+                  className="accent-brand-600 disabled:opacity-60 disabled:cursor-not-allowed"
                 />
                 Criar usuário no primeiro login (recomendado)
               </label>
@@ -326,56 +348,72 @@ export default function SsoSettings() {
           <div className="grid grid-cols-3 gap-3">
             <Field label="Claim de e-mail">
               <input
+                disabled={demo}
                 value={form.emailClaim}
                 onChange={(e) => setForm({ ...form, emailClaim: e.target.value })}
-                className="input font-mono text-xs"
+                className="input font-mono text-xs disabled:opacity-60 disabled:cursor-not-allowed"
               />
             </Field>
             <Field label="Claim de nome">
               <input
+                disabled={demo}
                 value={form.nameClaim}
                 onChange={(e) => setForm({ ...form, nameClaim: e.target.value })}
-                className="input font-mono text-xs"
+                className="input font-mono text-xs disabled:opacity-60 disabled:cursor-not-allowed"
               />
             </Field>
             <Field label="Claim de grupos">
               <input
+                disabled={demo}
                 value={form.groupsClaim}
                 onChange={(e) => setForm({ ...form, groupsClaim: e.target.value })}
-                className="input font-mono text-xs"
+                className="input font-mono text-xs disabled:opacity-60 disabled:cursor-not-allowed"
               />
             </Field>
           </div>
           <Field label="Scopes">
             <input
+              disabled={demo}
               value={form.scopes}
               onChange={(e) => setForm({ ...form, scopes: e.target.value })}
-              className="input font-mono text-xs"
+              className="input font-mono text-xs disabled:opacity-60 disabled:cursor-not-allowed"
             />
           </Field>
           <Field label="Texto do botão na tela de login">
             <input
+              disabled={demo}
               value={form.buttonLabel}
               onChange={(e) => setForm({ ...form, buttonLabel: e.target.value })}
-              className="input"
+              className="input disabled:opacity-60 disabled:cursor-not-allowed"
             />
           </Field>
         </Section>
 
         <div className="flex items-center gap-2 sticky bottom-0 bg-white/90 dark:bg-slate-900/80 backdrop-blur p-3 rounded-xl border border-slate-100 dark:border-slate-800">
-          <button type="submit" className="btn-primary" disabled={save.isPending}>
+          <button
+            type="submit"
+            className="btn-primary disabled:opacity-50 disabled:cursor-not-allowed"
+            disabled={demo || save.isPending}
+            title={demo ? 'Desabilitado no ambiente de demonstração' : ''}
+          >
             <Save size={14} />
             {save.isPending ? 'Salvando…' : 'Salvar configurações'}
           </button>
           <button
             type="button"
             onClick={() => test.mutate()}
-            className="btn-ghost"
-            disabled={test.isPending}
+            className="btn-ghost disabled:opacity-50 disabled:cursor-not-allowed"
+            disabled={demo || test.isPending}
+            title={demo ? 'Desabilitado no ambiente de demonstração' : ''}
           >
             <Activity size={14} />
             {test.isPending ? 'Testando…' : 'Testar conexão'}
           </button>
+          {demo && (
+            <p className="text-xs text-slate-400">
+              Configuração somente leitura no ambiente de demonstração.
+            </p>
+          )}
           {cfg?.lastTestedAt && (
             <span className="text-xs text-slate-500 ml-auto">
               último teste:{' '}

--- a/apps/web/src/pages/SubnetDetail.jsx
+++ b/apps/web/src/pages/SubnetDetail.jsx
@@ -107,8 +107,19 @@ export default function SubnetDetail() {
   const [searchParams] = useSearchParams();
   const highlightIp = searchParams.get('ip');
   const { user } = useAuth();
-  const canEdit = user?.role === 'ADMIN';
   const navigate = useNavigate();
+
+  // No ambiente de demonstração tudo é somente-leitura (a API bloqueia toda
+  // escrita). Escondemos qualquer controle que crie/edite/libere/aloque IP,
+  // edição inline e ações em massa pra não confundir nem passar impressão de
+  // insegurança. `canEdit` passa a refletir também esse estado.
+  const { data: appCfg } = useQuery({
+    queryKey: ['app-config'],
+    queryFn: api.config,
+    staleTime: 60_000,
+  });
+  const demo = !!appCfg?.demo?.enabled;
+  const canEdit = user?.role === 'ADMIN' && !demo;
 
   const [q, setQ] = useState('');
   const [status, setStatus] = useState('');

--- a/apps/web/src/pages/Users.jsx
+++ b/apps/web/src/pages/Users.jsx
@@ -18,6 +18,15 @@ export default function Users() {
   const { user: me } = useAuth();
   const qc = useQueryClient();
   const { data: users = [] } = useQuery({ queryKey: ['users'], queryFn: api.users });
+  // No ambiente de demonstração tudo é somente-leitura (a API bloqueia toda
+  // escrita). Escondemos as ações de gestão de usuários (reset/desativar/excluir/
+  // trocar papel/criar) pra não confundir nem passar impressão de insegurança.
+  const { data: appCfg } = useQuery({
+    queryKey: ['app-config'],
+    queryFn: api.config,
+    staleTime: 60_000,
+  });
+  const demo = !!appCfg?.demo?.enabled;
   const [showCreate, setShowCreate] = useState(false);
   const [linkInfo, setLinkInfo] = useState(null);
 
@@ -61,9 +70,11 @@ export default function Users() {
         title="Usuários"
         description="ADMIN pode editar tudo (incluindo criar usuários). READER só consulta. Ao criar uma conta sem senha, geramos um link único de definição."
         actions={
-          <button onClick={() => setShowCreate(true)} className="btn-primary">
-            <UserPlus size={14} /> Novo usuário
-          </button>
+          demo ? null : (
+            <button onClick={() => setShowCreate(true)} className="btn-primary">
+              <UserPlus size={14} /> Novo usuário
+            </button>
+          )
         }
       />
 
@@ -89,11 +100,11 @@ export default function Users() {
                 <td className="px-3 py-2">
                   <select
                     value={u.role}
-                    disabled={u.id === me?.id}
+                    disabled={u.id === me?.id || demo}
                     onChange={(e) =>
                       update.mutate({ id: u.id, data: { role: e.target.value } })
                     }
-                    className="input py-0.5 text-xs w-auto"
+                    className="input py-0.5 text-xs w-auto disabled:opacity-60"
                   >
                     <option value="ADMIN">ADMIN</option>
                     <option value="READER">READER</option>
@@ -121,33 +132,39 @@ export default function Users() {
                     : 'nunca'}
                 </td>
                 <td className="px-3 py-2 text-right whitespace-nowrap">
-                  <button
-                    onClick={() => reset.mutate(u.id)}
-                    title="Gerar link de reset"
-                    className="text-xs px-2 py-0.5 rounded bg-amber-100 text-amber-700 hover:bg-amber-200 dark:bg-amber-900/40 dark:text-amber-300 mr-1"
-                  >
-                    <KeyRound size={12} className="inline" /> reset
-                  </button>
-                  <button
-                    onClick={() =>
-                      update.mutate({ id: u.id, data: { active: !u.active } })
-                    }
-                    disabled={u.id === me?.id}
-                    title={u.active ? 'Desativar' : 'Reativar'}
-                    className="text-xs px-2 py-0.5 rounded bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 mr-1"
-                  >
-                    <Power size={12} className="inline" /> {u.active ? 'desativar' : 'reativar'}
-                  </button>
-                  <button
-                    onClick={() => {
-                      if (confirm(`Remover ${u.email}?`)) remove.mutate(u.id);
-                    }}
-                    disabled={u.id === me?.id}
-                    title="Remover"
-                    className="text-rose-500 hover:text-rose-700 disabled:opacity-30 p-1"
-                  >
-                    <Trash2 size={14} />
-                  </button>
+                  {demo ? (
+                    <span className="text-xs text-slate-400 italic">somente leitura</span>
+                  ) : (
+                    <>
+                      <button
+                        onClick={() => reset.mutate(u.id)}
+                        title="Gerar link de reset"
+                        className="text-xs px-2 py-0.5 rounded bg-amber-100 text-amber-700 hover:bg-amber-200 dark:bg-amber-900/40 dark:text-amber-300 mr-1"
+                      >
+                        <KeyRound size={12} className="inline" /> reset
+                      </button>
+                      <button
+                        onClick={() =>
+                          update.mutate({ id: u.id, data: { active: !u.active } })
+                        }
+                        disabled={u.id === me?.id}
+                        title={u.active ? 'Desativar' : 'Reativar'}
+                        className="text-xs px-2 py-0.5 rounded bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 mr-1"
+                      >
+                        <Power size={12} className="inline" /> {u.active ? 'desativar' : 'reativar'}
+                      </button>
+                      <button
+                        onClick={() => {
+                          if (confirm(`Remover ${u.email}?`)) remove.mutate(u.id);
+                        }}
+                        disabled={u.id === me?.id}
+                        title="Remover"
+                        className="text-rose-500 hover:text-rose-700 disabled:opacity-30 p-1"
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    </>
+                  )}
                 </td>
               </tr>
             ))}

--- a/apps/web/src/pages/ValidationRules.jsx
+++ b/apps/web/src/pages/ValidationRules.jsx
@@ -42,6 +42,11 @@ export default function ValidationRules() {
   const qc = useQueryClient();
   const toast = useToast();
   const { data: rules = [], isLoading } = useQuery({ queryKey: ['validation-rules'], queryFn: api.validationRules });
+  // Em modo demonstração tudo é somente-leitura (a API bloqueia toda escrita).
+  // Escondemos criar/editar/excluir/ativar regra; mantemos os cards explicativos
+  // ("Como funciona", tipos de regra) e a listagem visíveis.
+  const { data: appCfg } = useQuery({ queryKey: ['app-config'], queryFn: api.config, staleTime: 60_000 });
+  const demo = !!appCfg?.demo?.enabled;
   const [modal, setModal] = useState({ open: false, rule: null });
   const [confirm, setConfirm] = useState({ open: false, id: null, label: '' });
 
@@ -57,9 +62,11 @@ export default function ValidationRules() {
         title="Regras de validação"
         description="Regras rodam antes de criar ou alterar uma subnet. Erros bloqueiam; warnings só avisam."
         actions={
-          <button onClick={() => setModal({ open: true, rule: null })} className="btn-primary inline-flex items-center gap-1.5">
-            <Plus size={14} /> Nova regra
-          </button>
+          demo ? null : (
+            <button onClick={() => setModal({ open: true, rule: null })} className="btn-primary inline-flex items-center gap-1.5">
+              <Plus size={14} /> Nova regra
+            </button>
+          )
         }
       />
 
@@ -89,9 +96,11 @@ export default function ValidationRules() {
           <p className="text-sm text-slate-500 mb-4 max-w-md mx-auto">
             Sem regras, qualquer ADMIN pode criar qualquer subnet sem checks. Adicione pelo menos uma <strong>no-overlap</strong> pra evitar conflitos acidentais.
           </p>
-          <button onClick={() => setModal({ open: true, rule: null })} className="btn-primary inline-flex items-center gap-1.5">
-            <Plus size={14} /> Adicionar primeira regra
-          </button>
+          {!demo && (
+            <button onClick={() => setModal({ open: true, rule: null })} className="btn-primary inline-flex items-center gap-1.5">
+              <Plus size={14} /> Adicionar primeira regra
+            </button>
+          )}
 
           <div className="mt-8 text-left max-w-2xl mx-auto">
             <p className="text-xs font-semibold uppercase tracking-wider text-slate-400 mb-2">Tipos de regra disponíveis</p>
@@ -128,7 +137,7 @@ export default function ValidationRules() {
                 return (
                   <tr key={r.id}>
                     <td className="px-3 py-2">
-                      <input type="checkbox" checked={r.enabled} onChange={(e) => toggleMut.mutate({ id: r.id, enabled: e.target.checked })} className="accent-brand-600 cursor-pointer" />
+                      <input type="checkbox" checked={r.enabled} disabled={demo} onChange={(e) => toggleMut.mutate({ id: r.id, enabled: e.target.checked })} className="accent-brand-600 cursor-pointer disabled:cursor-default disabled:opacity-60" />
                     </td>
                     <td className="px-3 py-2 font-medium">{r.name}</td>
                     <td className="px-3 py-2">
@@ -144,8 +153,14 @@ export default function ValidationRules() {
                     <td className="px-3 py-2 text-xs text-slate-500">{r.scope || 'global'}</td>
                     <td className="px-3 py-2 text-[11px] font-mono text-slate-600">{JSON.stringify(r.config)}</td>
                     <td className="px-3 py-2 text-right whitespace-nowrap">
-                      <button onClick={() => setModal({ open: true, rule: r })} className="text-slate-400 hover:text-brand-600 p-1 rounded hover:bg-slate-100 dark:hover:bg-slate-800" title="Editar"><Pencil size={14} /></button>
-                      <button onClick={() => setConfirm({ open: true, id: r.id, label: r.name })} className="text-slate-400 hover:text-rose-600 p-1 rounded hover:bg-rose-50 dark:hover:bg-rose-900/30 ml-1" title="Excluir"><Trash2 size={14} /></button>
+                      {demo ? (
+                        <span className="text-xs text-slate-400 italic">somente leitura</span>
+                      ) : (
+                        <>
+                          <button onClick={() => setModal({ open: true, rule: r })} className="text-slate-400 hover:text-brand-600 p-1 rounded hover:bg-slate-100 dark:hover:bg-slate-800" title="Editar"><Pencil size={14} /></button>
+                          <button onClick={() => setConfirm({ open: true, id: r.id, label: r.name })} className="text-slate-400 hover:text-rose-600 p-1 rounded hover:bg-rose-50 dark:hover:bg-rose-900/30 ml-1" title="Excluir"><Trash2 size={14} /></button>
+                        </>
+                      )}
                     </td>
                   </tr>
                 );

--- a/apps/web/src/pages/ZabbixSettings.jsx
+++ b/apps/web/src/pages/ZabbixSettings.jsx
@@ -20,6 +20,14 @@ export default function ZabbixSettings() {
     queryKey: ['zabbix-config'],
     queryFn: api.zabbixConfig,
   });
+  // No ambiente de demonstração tudo é somente-leitura (a API bloqueia toda
+  // escrita). Desabilitamos salvar/testar/sincronizar e os campos do form.
+  const { data: appCfg } = useQuery({
+    queryKey: ['app-config'],
+    queryFn: api.config,
+    staleTime: 60_000,
+  });
+  const demo = !!appCfg?.demo?.enabled;
   const [form, setForm] = useState(null);
   const [groupsCsv, setGroupsCsv] = useState('');
 
@@ -109,9 +117,15 @@ export default function ZabbixSettings() {
         actions={
           <button
             onClick={() => enable.mutate()}
-            disabled={!fullyConfigured || enable.isPending}
-            className={form.enabled ? 'btn-danger' : 'btn-primary'}
-            title={!fullyConfigured ? 'Configure URL e token antes de habilitar' : ''}
+            disabled={demo || !fullyConfigured || enable.isPending}
+            className={`${form.enabled ? 'btn-danger' : 'btn-primary'} disabled:opacity-50 disabled:cursor-not-allowed`}
+            title={
+              demo
+                ? 'Desabilitado no ambiente de demonstração'
+                : !fullyConfigured
+                ? 'Configure URL e token antes de habilitar'
+                : ''
+            }
           >
             <Power size={14} />
             {form.enabled ? 'Pausar' : 'Habilitar sincronização'}
@@ -129,10 +143,11 @@ export default function ZabbixSettings() {
           >
             <input
               required
+              disabled={demo}
               value={form.url}
               onChange={(e) => setForm({ ...form, url: e.target.value })}
               placeholder="https://zabbix.empresa.local"
-              className="input font-mono text-xs"
+              className="input font-mono text-xs disabled:opacity-60 disabled:cursor-not-allowed"
             />
           </Field>
           <Field
@@ -145,10 +160,11 @@ export default function ZabbixSettings() {
           >
             <input
               type="password"
+              disabled={demo}
               value={form.apiToken}
               onChange={(e) => setForm({ ...form, apiToken: e.target.value })}
               placeholder={cfg?.hasApiToken ? '•••••••• (mantém o atual)' : ''}
-              className="input"
+              className="input disabled:opacity-60 disabled:cursor-not-allowed"
             />
           </Field>
           <details className="text-sm">
@@ -158,18 +174,20 @@ export default function ZabbixSettings() {
             <div className="mt-3 space-y-3 pl-4 border-l-2 border-slate-100 dark:border-slate-700">
               <Field label="Usuário">
                 <input
+                  disabled={demo}
                   value={form.username}
                   onChange={(e) => setForm({ ...form, username: e.target.value })}
-                  className="input"
+                  className="input disabled:opacity-60 disabled:cursor-not-allowed"
                 />
               </Field>
               <Field label="Senha">
                 <input
                   type="password"
+                  disabled={demo}
                   value={form.password}
                   onChange={(e) => setForm({ ...form, password: e.target.value })}
                   placeholder={cfg?.hasPassword ? '•••••••• (mantém a atual)' : ''}
-                  className="input"
+                  className="input disabled:opacity-60 disabled:cursor-not-allowed"
                 />
               </Field>
             </div>
@@ -185,9 +203,10 @@ export default function ZabbixSettings() {
               <input
                 type="number"
                 min="1"
+                disabled={demo}
                 value={form.intervalMinutes}
                 onChange={(e) => setForm({ ...form, intervalMinutes: e.target.value })}
-                className="input"
+                className="input disabled:opacity-60 disabled:cursor-not-allowed"
               />
             </Field>
             <Field
@@ -197,9 +216,10 @@ export default function ZabbixSettings() {
               <input
                 type="number"
                 min="1"
+                disabled={demo}
                 value={form.staleAfterDays}
                 onChange={(e) => setForm({ ...form, staleAfterDays: e.target.value })}
-                className="input"
+                className="input disabled:opacity-60 disabled:cursor-not-allowed"
               />
             </Field>
           </div>
@@ -208,24 +228,31 @@ export default function ZabbixSettings() {
             hint="Deixe vazio para sincronizar todos os hosts. Nomes separados por vírgula."
           >
             <input
+              disabled={demo}
               value={groupsCsv}
               onChange={(e) => setGroupsCsv(e.target.value)}
               placeholder="Production, Equinix-SP3, Customer X"
-              className="input"
+              className="input disabled:opacity-60 disabled:cursor-not-allowed"
             />
           </Field>
         </Section>
 
         <div className="flex items-center gap-2 sticky bottom-0 bg-white/90 dark:bg-slate-900/80 backdrop-blur p-3 rounded-xl border border-slate-100 dark:border-slate-800">
-          <button type="submit" className="btn-primary" disabled={save.isPending}>
+          <button
+            type="submit"
+            className="btn-primary disabled:opacity-50 disabled:cursor-not-allowed"
+            disabled={demo || save.isPending}
+            title={demo ? 'Desabilitado no ambiente de demonstração' : ''}
+          >
             <Save size={14} />
             {save.isPending ? 'Salvando…' : 'Salvar'}
           </button>
           <button
             type="button"
             onClick={() => test.mutate()}
-            className="btn-ghost"
-            disabled={test.isPending}
+            className="btn-ghost disabled:opacity-50 disabled:cursor-not-allowed"
+            disabled={demo || test.isPending}
+            title={demo ? 'Desabilitado no ambiente de demonstração' : ''}
           >
             <Activity size={14} />
             {test.isPending ? 'Testando…' : 'Testar conexão'}
@@ -233,9 +260,15 @@ export default function ZabbixSettings() {
           <button
             type="button"
             onClick={() => sync.mutate()}
-            className="btn-ghost"
-            disabled={sync.isPending || !fullyConfigured}
-            title={!fullyConfigured ? 'Configure tudo antes' : ''}
+            className="btn-ghost disabled:opacity-50 disabled:cursor-not-allowed"
+            disabled={demo || sync.isPending || !fullyConfigured}
+            title={
+              demo
+                ? 'Desabilitado no ambiente de demonstração'
+                : !fullyConfigured
+                ? 'Configure tudo antes'
+                : ''
+            }
           >
             <RefreshCcw
               size={14}
@@ -243,6 +276,11 @@ export default function ZabbixSettings() {
             />
             {sync.isPending ? 'Sincronizando…' : 'Sincronizar agora'}
           </button>
+          {demo && (
+            <p className="text-xs text-slate-400">
+              Configuração somente leitura no ambiente de demonstração.
+            </p>
+          )}
           {cfg?.lastTestedAt && (
             <span className="text-xs text-slate-500 ml-auto">
               último teste:{' '}


### PR DESCRIPTION
## O quê
No ambiente de demonstração público, a UI ainda mostrava botões de criar/editar/excluir/aprovar/sync. A API já bloqueava (403), mas era confuso e passava impressão de insegurança (o usuário viu botões "desativar"/"excluir" usuário no demo).

## Como
- **`api.js` — trava central de escrita:** em demo, toda requisição `POST/PUT/PATCH/DELETE` (exceto `/auth/login`) é barrada **antes de sair**, com toast "somente leitura". Defesa em profundidade + UX limpa; pega qualquer botão de qualquer página, inclusive futuras.
- **`Layout.jsx`:** liga `setDemoMode(isDemo)` e o handler do aviso.
- **Páginas de dados** (Sites, SubnetDetail, Devices, Catalogs, CloudAccounts, ValidationRules, PendingDiscoveries, Users): escondem criar/editar/excluir/aprovar/sync; ações inline viram "somente leitura".
- **Páginas de config** (Zabbix/Prometheus/DNS/SSO): formulário continua **visível**, mas save/test/sync e inputs ficam **desabilitados**.

## ⚠️ Só afeta o demo — self-host intacto
Tudo é gated em `demo.enabled`, que vem de `demo: DEMO ? {...} : null` no `/api/config`, com `DEMO = process.env.DEMO_MODE === 'true'`.

**Sem `DEMO_MODE=true` (self-host), `demo` é `false` → funcionalidade COMPLETA**, zero mudança de comportamento. O padrão `canEdit = role === 'ADMIN' && !demo` vira exatamente `role === 'ADMIN'` — ADMIN/READER idêntico ao de antes.

## Teste
- `npx vite build` verde com as 14 alterações juntas.
- Verificado server-side: `/api/config` só emite `demo` quando `DEMO_MODE=true`.
