### PR TITLE
feat(demo): aviso 'Somente demonstração' já no clique de criar/editar/excluir

### DIFF
--- a/apps/web/src/api.js
+++ b/apps/web/src/api.js
@@ -26,6 +26,22 @@ export function setDemoBlockHandler(fn) {
 }
 const WRITE_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 
+// Guard para ações com INTENÇÃO de escrita que NÃO são chamadas de API por si só
+// — abrir um modal de criar/editar, ou um fluxo de excluir com confirmação. No
+// demo, mostra o aviso na hora e devolve true (= bloqueado), pra UI abortar antes
+// de abrir o formulário. Fora do demo devolve false (segue normal).
+// Uso típico:  onClick={() => { if (demoTryWrite()) return; abrirModal(); }}
+export function demoTryWrite() {
+  if (demoMode) {
+    onDemoBlock();
+    return true;
+  }
+  return false;
+}
+export function isDemoMode() {
+  return demoMode;
+}
+
 async function request(path, opts = {}) {
   const method = (opts.method || 'GET').toUpperCase();
   // Login é o único write permitido na demo (é como o visitante entra).

--- a/apps/web/src/pages/Catalogs.jsx
+++ b/apps/web/src/pages/Catalogs.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 import { Plus, Pencil, Trash2, Cloud, RefreshCw, ExternalLink } from 'lucide-react';
-import { api } from '../api.js';
+import { api, demoTryWrite } from '../api.js';
 import { useAuth } from '../auth/AuthContext.jsx';
 import PageHeader from '../components/PageHeader.jsx';
 import CatalogFormModal from '../components/CatalogFormModal.jsx';
@@ -244,7 +244,7 @@ function MasterRanges({ canEdit }) {
 
   return (
     <div>
-      <Toolbar canEdit={canEdit} label="Novo range mestre" onNew={() => { setErr(null); setModal({ open: true, initial: null }); }} />
+      <Toolbar canEdit={canEdit} label="Novo range mestre" onNew={() => { if (demoTryWrite()) return; setErr(null); setModal({ open: true, initial: null }); }} />
       <div className="card overflow-hidden">
         <table className="w-full text-sm table-zebra">
           <thead className="bg-slate-50 dark:bg-slate-800/50 text-xs uppercase text-slate-500">
@@ -263,8 +263,8 @@ function MasterRanges({ canEdit }) {
                 <td className="px-3 py-1.5 text-slate-500">{r.category || '—'}</td>
                 <ActionCell
                   canEdit={canEdit}
-                  onEdit={() => { setErr(null); setModal({ open: true, initial: r }); }}
-                  onDelete={() => setConfirm({ open: true, id: r.id, label: r.cidr })}
+                  onEdit={() => { if (demoTryWrite()) return; setErr(null); setModal({ open: true, initial: r }); }}
+                  onDelete={() => { if (demoTryWrite()) return; setConfirm({ open: true, id: r.id, label: r.cidr }); }}
                 />
               </tr>
             ))}
@@ -321,7 +321,7 @@ function DatacenterVlans({ canEdit }) {
 
   return (
     <div>
-      <Toolbar canEdit={canEdit} label="Nova VLAN" onNew={() => { setErr(null); setModal({ open: true, initial: null }); }} />
+      <Toolbar canEdit={canEdit} label="Nova VLAN" onNew={() => { if (demoTryWrite()) return; setErr(null); setModal({ open: true, initial: null }); }} />
       <div className="card overflow-hidden">
         <table className="w-full text-sm table-zebra">
           <thead className="bg-slate-50 dark:bg-slate-800/50 text-xs uppercase text-slate-500">
@@ -346,8 +346,8 @@ function DatacenterVlans({ canEdit }) {
                 <td className="px-3 py-1.5 font-mono text-xs">{r.broadcast || '—'}</td>
                 <ActionCell
                   canEdit={canEdit}
-                  onEdit={() => { setErr(null); setModal({ open: true, initial: r }); }}
-                  onDelete={() => setConfirm({ open: true, id: r.id, label: r.name })}
+                  onEdit={() => { if (demoTryWrite()) return; setErr(null); setModal({ open: true, initial: r }); }}
+                  onDelete={() => { if (demoTryWrite()) return; setConfirm({ open: true, id: r.id, label: r.name }); }}
                 />
               </tr>
             ))}

--- a/apps/web/src/pages/CloudAccounts.jsx
+++ b/apps/web/src/pages/CloudAccounts.jsx
@@ -18,7 +18,7 @@ import {
   KeyRound,
   ShieldCheck,
 } from 'lucide-react';
-import { api } from '../api.js';
+import { api, demoTryWrite } from '../api.js';
 import PageHeader from '../components/PageHeader.jsx';
 import Modal from '../components/Modal.jsx';
 import { useToast } from '../components/Toast.jsx';
@@ -323,7 +323,7 @@ function AccountCard({ account, onSync, onTest, onDelete, syncing }) {
         </button>
         <div className="flex-1" />
         <button
-          onClick={() => onDelete(account.id, account.displayName)}
+          onClick={() => { if (demoTryWrite()) return; onDelete(account.id, account.displayName); }}
           className="text-xs px-2 py-1.5 rounded text-rose-600 hover:bg-rose-50 dark:hover:bg-rose-900/30 inline-flex items-center gap-1"
         >
           <Trash2 size={12} />
@@ -744,7 +744,7 @@ export default function CloudAccounts() {
         title="Cloud Accounts"
         description="Conecte AWS / Azure / GCP e o Bagre importa subnets e IPs automaticamente. Use a auditoria abaixo para identificar IPs públicos ociosos e decidir o que pode ser liberado."
         actions={
-          <button onClick={() => setAddOpen(true)} className="btn-primary inline-flex items-center gap-1.5">
+          <button onClick={() => { if (demoTryWrite()) return; setAddOpen(true); }} className="btn-primary inline-flex items-center gap-1.5">
             <Plus size={14} />
             Conectar conta
           </button>
@@ -761,7 +761,7 @@ export default function CloudAccounts() {
           <p className="text-sm text-slate-500 mb-4 max-w-md mx-auto">
             Conecte sua AWS em menos de 2 minutos. Cria-se um IAM User (ou Role) com permissão read-only, cola credenciais aqui — o Bagre testa e sincroniza na hora.
           </p>
-          <button onClick={() => setAddOpen(true)} className="btn-primary inline-flex items-center gap-1.5">
+          <button onClick={() => { if (demoTryWrite()) return; setAddOpen(true); }} className="btn-primary inline-flex items-center gap-1.5">
             <Plus size={14} />
             Conectar primeira conta
           </button>

--- a/apps/web/src/pages/Devices.jsx
+++ b/apps/web/src/pages/Devices.jsx
@@ -2,7 +2,7 @@ import { useState, useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 import { Search, Plus, Pencil, Trash2, ExternalLink, Server } from 'lucide-react';
-import { api } from '../api.js';
+import { api, demoTryWrite } from '../api.js';
 import { useAuth } from '../auth/AuthContext.jsx';
 import PageHeader from '../components/PageHeader.jsx';
 import CatalogFormModal from '../components/CatalogFormModal.jsx';
@@ -94,6 +94,7 @@ export default function Devices() {
           canEdit && (
             <button
               onClick={() => {
+                if (demoTryWrite()) return;
                 setErr(null);
                 setModal({ open: true, initial: null });
               }}
@@ -204,6 +205,7 @@ export default function Devices() {
                   >
                     <button
                       onClick={() => {
+                        if (demoTryWrite()) return;
                         setErr(null);
                         setModal({ open: true, initial: d });
                       }}
@@ -213,7 +215,10 @@ export default function Devices() {
                       <Pencil size={14} />
                     </button>
                     <button
-                      onClick={() => setConfirm({ open: true, device: d })}
+                      onClick={() => {
+                        if (demoTryWrite()) return;
+                        setConfirm({ open: true, device: d });
+                      }}
                       className="text-slate-400 hover:text-rose-600 p-1 rounded hover:bg-rose-50 dark:hover:bg-rose-900/30 ml-1"
                       title="Excluir (libera IPs vinculados)"
                     >
@@ -308,7 +313,13 @@ function DeviceDetailModal({ deviceId, onClose, canEdit, onEdit }) {
               </div>
               <div className="flex gap-2">
                 {canEdit && (
-                  <button onClick={() => onEdit(data)} className="btn-ghost text-xs">
+                  <button
+                    onClick={() => {
+                      if (demoTryWrite()) return;
+                      onEdit(data);
+                    }}
+                    className="btn-ghost text-xs"
+                  >
                     <Pencil size={13} /> Editar
                   </button>
                 )}

--- a/apps/web/src/pages/PendingDiscoveries.jsx
+++ b/apps/web/src/pages/PendingDiscoveries.jsx
@@ -11,7 +11,7 @@ import {
   CheckCircle2,
   XCircle,
 } from 'lucide-react';
-import { api } from '../api.js';
+import { api, demoTryWrite } from '../api.js';
 import { useAuth } from '../auth/AuthContext.jsx';
 import PageHeader from '../components/PageHeader.jsx';
 import Modal from '../components/Modal.jsx';
@@ -199,6 +199,7 @@ export default function PendingDiscoveries() {
           </div>
           <button
             onClick={() => {
+              if (demoTryWrite()) return;
               setErr(null);
               const ids = Array.from(selected);
               const subset = discoveries.filter((d) => selected.has(d.id));
@@ -251,6 +252,7 @@ export default function PendingDiscoveries() {
                     </button>
                     <button
                       onClick={() => {
+                        if (demoTryWrite()) return;
                         setErr(null);
                         setApproveModal({
                           open: true,
@@ -275,6 +277,7 @@ export default function PendingDiscoveries() {
                 selected={selected}
                 onToggle={toggleSelect}
                 onApprove={(d) => {
+                  if (demoTryWrite()) return;
                   setErr(null);
                   setApproveModal({
                     open: true,
@@ -283,7 +286,10 @@ export default function PendingDiscoveries() {
                     suggestedSite: d.suggestedSiteCode || null,
                   });
                 }}
-                onReject={(d) => setRejectModal({ open: true, id: d.id })}
+                onReject={(d) => {
+                  if (demoTryWrite()) return;
+                  setRejectModal({ open: true, id: d.id });
+                }}
               />
             </div>
           ))}

--- a/apps/web/src/pages/Sites.jsx
+++ b/apps/web/src/pages/Sites.jsx
@@ -9,7 +9,7 @@ import {
   Pencil,
   Trash2,
 } from 'lucide-react';
-import { api } from '../api.js';
+import { api, demoTryWrite } from '../api.js';
 import { useAuth } from '../auth/AuthContext.jsx';
 import PageHeader from '../components/PageHeader.jsx';
 import SiteFormModal from '../components/SiteFormModal.jsx';
@@ -186,6 +186,7 @@ export default function Sites() {
           canEdit && (
             <button
               onClick={() => {
+                if (demoTryWrite()) return;
                 setFormError(null);
                 setSiteModal({ open: true, initial: null });
               }}
@@ -238,6 +239,7 @@ export default function Sites() {
                           label: 'Nova subnet',
                           icon: <Plus size={14} />,
                           onClick: () => {
+                            if (demoTryWrite()) return;
                             setFormError(null);
                             setSubnetModal({
                               open: true,
@@ -251,6 +253,7 @@ export default function Sites() {
                           label: 'Editar site',
                           icon: <Pencil size={14} />,
                           onClick: () => {
+                            if (demoTryWrite()) return;
                             setFormError(null);
                             setSiteModal({ open: true, initial: site });
                           },
@@ -259,14 +262,16 @@ export default function Sites() {
                           label: 'Excluir site',
                           icon: <Trash2 size={14} />,
                           danger: true,
-                          onClick: () =>
+                          onClick: () => {
+                            if (demoTryWrite()) return;
                             setConfirm({
                               type: 'site',
                               id: site.id,
                               code: site.code,
                               subnetCount: site.subnets.length,
                               ipCount: total,
-                            }),
+                            });
+                          },
                         },
                       ]}
                     />
@@ -323,6 +328,7 @@ export default function Sites() {
                                 label: 'Editar subnet',
                                 icon: <Pencil size={14} />,
                                 onClick: () => {
+                                  if (demoTryWrite()) return;
                                   setFormError(null);
                                   setSubnetModal({
                                     open: true,
@@ -336,14 +342,16 @@ export default function Sites() {
                                 label: 'Excluir subnet',
                                 icon: <Trash2 size={14} />,
                                 danger: true,
-                                onClick: () =>
+                                onClick: () => {
+                                  if (demoTryWrite()) return;
                                   setConfirm({
                                     type: 'subnet',
                                     id: sub.id,
                                     name: sub.name,
                                     siteCode: site.code,
                                     ipCount: sub.ipCount,
-                                  }),
+                                  });
+                                },
                               },
                             ]}
                           />
@@ -354,6 +362,7 @@ export default function Sites() {
                   {canEdit && site.subnets.length === 0 && (
                     <button
                       onClick={() => {
+                        if (demoTryWrite()) return;
                         setFormError(null);
                         setSubnetModal({
                           open: true,

--- a/apps/web/src/pages/SubnetDetail.jsx
+++ b/apps/web/src/pages/SubnetDetail.jsx
@@ -15,7 +15,7 @@ import {
   Edit3,
   Trash2,
 } from 'lucide-react';
-import { api } from '../api.js';
+import { api, demoTryWrite } from '../api.js';
 import { useAuth } from '../auth/AuthContext.jsx';
 import StatusBadge from '../components/StatusBadge.jsx';
 import PageHeader from '../components/PageHeader.jsx';
@@ -40,7 +40,10 @@ function EditableCell({ value, onSave, placeholder = '—', disabled }) {
   if (!editing) {
     return (
       <button
-        onClick={() => setEditing(true)}
+        onClick={() => {
+          if (demoTryWrite()) return;
+          setEditing(true);
+        }}
         title="Clique para editar"
         className="w-full text-left px-2 py-1 rounded hover:bg-slate-100 dark:hover:bg-slate-800 truncate"
       >
@@ -203,6 +206,7 @@ export default function SubnetDetail() {
   });
 
   async function openNextFreeAllocate() {
+    if (demoTryWrite()) return;
     try {
       const next = await api.subnetNextFreeIp(subnetId);
       setAllocateError(null);
@@ -445,6 +449,7 @@ export default function SubnetDetail() {
                     {(ip.status === 'FREE' || ip.status === 'RESERVED') && (
                       <button
                         onClick={() => {
+                          if (demoTryWrite()) return;
                           setAllocateError(null);
                           setAllocateModal({ open: true, ip });
                         }}
@@ -507,7 +512,10 @@ export default function SubnetDetail() {
           onReserve={() => {
             bulkMut.mutate({ ipIds: Array.from(selected), action: 'reserve' });
           }}
-          onEdit={() => setBulkEditOpen(true)}
+          onEdit={() => {
+            if (demoTryWrite()) return;
+            setBulkEditOpen(true);
+          }}
         />
       )}
 

--- a/apps/web/src/pages/Users.jsx
+++ b/apps/web/src/pages/Users.jsx
@@ -10,7 +10,7 @@ import {
   Copy,
   CheckCircle2,
 } from 'lucide-react';
-import { api } from '../api.js';
+import { api, demoTryWrite } from '../api.js';
 import { useAuth } from '../auth/AuthContext.jsx';
 import PageHeader from '../components/PageHeader.jsx';
 
@@ -61,7 +61,7 @@ export default function Users() {
         title="Usuários"
         description="ADMIN pode editar tudo (incluindo criar usuários). READER só consulta. Ao criar uma conta sem senha, geramos um link único de definição."
         actions={
-          <button onClick={() => setShowCreate(true)} className="btn-primary">
+          <button onClick={() => { if (demoTryWrite()) return; setShowCreate(true); }} className="btn-primary">
             <UserPlus size={14} /> Novo usuário
           </button>
         }
@@ -140,6 +140,7 @@ export default function Users() {
                   </button>
                   <button
                     onClick={() => {
+                      if (demoTryWrite()) return;
                       if (confirm(`Remover ${u.email}?`)) remove.mutate(u.id);
                     }}
                     disabled={u.id === me?.id}

--- a/apps/web/src/pages/ValidationRules.jsx
+++ b/apps/web/src/pages/ValidationRules.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Plus, Pencil, Trash2, Shield, AlertTriangle, AlertCircle } from 'lucide-react';
-import { api } from '../api.js';
+import { api, demoTryWrite } from '../api.js';
 import PageHeader from '../components/PageHeader.jsx';
 import Modal from '../components/Modal.jsx';
 import ConfirmDialog from '../components/ConfirmDialog.jsx';
@@ -57,7 +57,7 @@ export default function ValidationRules() {
         title="Regras de validação"
         description="Regras rodam antes de criar ou alterar uma subnet. Erros bloqueiam; warnings só avisam."
         actions={
-          <button onClick={() => setModal({ open: true, rule: null })} className="btn-primary inline-flex items-center gap-1.5">
+          <button onClick={() => { if (demoTryWrite()) return; setModal({ open: true, rule: null }); }} className="btn-primary inline-flex items-center gap-1.5">
             <Plus size={14} /> Nova regra
           </button>
         }
@@ -89,7 +89,7 @@ export default function ValidationRules() {
           <p className="text-sm text-slate-500 mb-4 max-w-md mx-auto">
             Sem regras, qualquer ADMIN pode criar qualquer subnet sem checks. Adicione pelo menos uma <strong>no-overlap</strong> pra evitar conflitos acidentais.
           </p>
-          <button onClick={() => setModal({ open: true, rule: null })} className="btn-primary inline-flex items-center gap-1.5">
+          <button onClick={() => { if (demoTryWrite()) return; setModal({ open: true, rule: null }); }} className="btn-primary inline-flex items-center gap-1.5">
             <Plus size={14} /> Adicionar primeira regra
           </button>
 
@@ -144,8 +144,8 @@ export default function ValidationRules() {
                     <td className="px-3 py-2 text-xs text-slate-500">{r.scope || 'global'}</td>
                     <td className="px-3 py-2 text-[11px] font-mono text-slate-600">{JSON.stringify(r.config)}</td>
                     <td className="px-3 py-2 text-right whitespace-nowrap">
-                      <button onClick={() => setModal({ open: true, rule: r })} className="text-slate-400 hover:text-brand-600 p-1 rounded hover:bg-slate-100 dark:hover:bg-slate-800" title="Editar"><Pencil size={14} /></button>
-                      <button onClick={() => setConfirm({ open: true, id: r.id, label: r.name })} className="text-slate-400 hover:text-rose-600 p-1 rounded hover:bg-rose-50 dark:hover:bg-rose-900/30 ml-1" title="Excluir"><Trash2 size={14} /></button>
+                      <button onClick={() => { if (demoTryWrite()) return; setModal({ open: true, rule: r }); }} className="text-slate-400 hover:text-brand-600 p-1 rounded hover:bg-slate-100 dark:hover:bg-slate-800" title="Editar"><Pencil size={14} /></button>
+                      <button onClick={() => { if (demoTryWrite()) return; setConfirm({ open: true, id: r.id, label: r.name }); }} className="text-slate-400 hover:text-rose-600 p-1 rounded hover:bg-rose-50 dark:hover:bg-rose-900/30 ml-1" title="Excluir"><Trash2 size={14} /></button>
                     </td>
                   </tr>
                 );


### PR DESCRIPTION
## O quê
Complemento do #71: os botões de criar/editar/excluir/aprovar no demo agora mostram o aviso "Somente demonstração" IMEDIATAMENTE ao clicar — sem abrir o formulário nem o confirm.

Antes só as escritas diretas (salvar/sincronizar/desativar) avisavam, pela trava central. Os que abrem modal só avisavam ao salvar.

## Como
- api.js: helper demoTryWrite() — em demo mostra o toast e devolve true (UI aborta); fora do demo devolve false.
- 8 páginas: onClick de criar/editar/excluir/aprovar chamam `if (demoTryWrite()) return;` antes de abrir.
- Botões continuam VISÍVEIS. Self-host intacto (demoMode=false -> no-op).
