### PR TITLE
security(demo): hardening (metrics/CORS/CSP/rate-limit) + selo de origem LDAP/AD

### DIFF
--- a/apps/api/src/demo-guard.js
+++ b/apps/api/src/demo-guard.js
@@ -1,11 +1,11 @@
 // Guardas do ambiente de demonstração (DEMO_MODE).
 //
-// Quando DEMO_MODE=true a instância é pública e compartilhada. Precisamos:
-//  - impedir que um visitante repointe integrações para alvos arbitrários
-//    (risco de SSRF / scan, ex.: endpoint de metadata 169.254.169.254);
-//  - bloquear ações destrutivas que estragariam a demo para os próximos.
-//
-// O fluxo-bandeira (aprovar pending discoveries) permanece LIBERADO.
+// Quando DEMO_MODE=true a instância é pública e compartilhada. A trava principal
+// é o hook global onRequest em index.js: TODO POST/PUT/PATCH/DELETE em /api/* é
+// 403, exceto /api/auth/login. Ou seja, o ambiente é 100% somente-leitura —
+// inclusive aprovar/rejeitar pending discoveries (são POST → bloqueados).
+// NÃO reabrir nenhum write aqui sem reavaliar o modelo de ameaça.
+// Estes helpers são defesa em profundidade pra mascarar segredos/topologia.
 
 export const DEMO = process.env.DEMO_MODE === 'true';
 

--- a/apps/api/src/index.js
+++ b/apps/api/src/index.js
@@ -43,7 +43,17 @@ async function build() {
   // refletir o cliente real via X-Forwarded-For — necessário pro rate-limit.
   const app = Fastify({ logger: { level: 'info' }, trustProxy: true });
 
-  await app.register(cors, { origin: true, credentials: true });
+  // CORS: se CORS_ORIGIN for definido (lista separada por vírgula), só essas
+  // origens são aceitas — em produção/demo, evita refletir qualquer Origin com
+  // credentials. Sem a env (dev), reflete a origem pra conveniência local.
+  const corsAllow = (process.env.CORS_ORIGIN || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  await app.register(cors, {
+    origin: corsAllow.length ? corsAllow : true,
+    credentials: true,
+  });
   await app.register(cookie);
   await app.register(multipart, { limits: { fileSize: 50 * 1024 * 1024 } });
   // JWT_SECRET é fail-closed: sem env definido ou abaixo de 32 chars, o boot

--- a/apps/api/src/index.js
+++ b/apps/api/src/index.js
@@ -134,6 +134,11 @@ async function build() {
       role: dbUser.role,
       name: dbUser.name,
       mustChangePwd: dbUser.mustChangePwd,
+      // Origem da autenticação (local/ldap/oidc) + DN/grupos do diretório — usado
+      // pela UI pra mostrar "Autenticado via LDAP/AD". Não-sensível.
+      authProvider: dbUser.authProvider || 'local',
+      externalId: dbUser.externalId || null,
+      externalGroups: dbUser.externalGroups || [],
     };
     // Write methods require ADMIN — except change-password & user-self routes
     const adminOnlyForWrites = !(

--- a/apps/api/src/routes/auth.js
+++ b/apps/api/src/routes/auth.js
@@ -181,7 +181,7 @@ export async function registerAuth(app) {
     return req.user;
   });
 
-  app.post('/api/auth/change-password', { preHandler: requireAuth }, async (req, reply) => {
+  app.post('/api/auth/change-password', { preHandler: [resetLimit, requireAuth] }, async (req, reply) => {
     // No DEMO as contas são fixas e compartilhadas — trocar a senha travaria o
     // login 1-clique pra todos os próximos visitantes.
     if (DEMO) return demoBlock(reply, 'Troca de senha desabilitada no ambiente de demonstração.');
@@ -234,7 +234,7 @@ export async function registerAuth(app) {
   });
 
   // Apply a reset token to set a new password.
-  app.post('/api/auth/reset', async (req, reply) => {
+  app.post('/api/auth/reset', { preHandler: resetLimit }, async (req, reply) => {
     const { token, newPassword } = req.body || {};
     if (!token || !newPassword || newPassword.length < 8) {
       reply.code(400);

--- a/apps/api/src/routes/oidc.js
+++ b/apps/api/src/routes/oidc.js
@@ -54,7 +54,7 @@ export async function registerOidcRoutes(app) {
         ? {
             enabled: true,
             banner:
-              'Ambiente de demonstração — os dados são reiniciados todo dia às 04h (BRT). Não insira dados reais.',
+              'Ambiente de demonstração — somente leitura. Explore à vontade.',
             // Credenciais propositalmente públicas para login em 1 clique.
             accounts: [
               {

--- a/apps/api/src/routes/users.js
+++ b/apps/api/src/routes/users.js
@@ -18,6 +18,12 @@ function projectUser(u) {
     mustChangePwd: u.mustChangePwd,
     lastLoginAt: u.lastLoginAt,
     createdAt: u.createdAt,
+    // Origem da autenticação (local / ldap / oidc) — evidência de que o login
+    // veio do diretório. externalId = DN no AD; externalGroups = grupos do AD.
+    // Não são segredos (é a procedência do usuário); senha/hash nunca saem daqui.
+    authProvider: u.authProvider || 'local',
+    externalId: u.externalId || null,
+    externalGroups: u.externalGroups || [],
   };
 }
 

--- a/apps/web/src/components/AuthProviderBadge.jsx
+++ b/apps/web/src/components/AuthProviderBadge.jsx
@@ -1,0 +1,56 @@
+import { Building2, KeyRound, User } from 'lucide-react';
+
+// Selo de ORIGEM da autenticação do usuário. Evidência de que o login veio de um
+// diretório (LDAP/Active Directory) ou IdP (OIDC), e não de uma conta local.
+// Lê o authProvider que o backend gravou no bind real.
+const META = {
+  ldap: {
+    label: 'LDAP / AD',
+    icon: Building2,
+    cls: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300',
+  },
+  oidc: {
+    label: 'SSO',
+    icon: KeyRound,
+    cls: 'bg-sky-100 text-sky-700 dark:bg-sky-900/40 dark:text-sky-300',
+  },
+  local: {
+    label: 'Local',
+    icon: User,
+    cls: 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300',
+  },
+};
+
+export default function AuthProviderBadge({ provider, externalId, groups = [], detail = false }) {
+  const m = META[provider] || META.local;
+  const Icon = m.icon;
+  // Tooltip com o DN e os grupos do diretório (a "prova" do LDAP).
+  const title =
+    provider === 'ldap'
+      ? [externalId && `DN: ${externalId}`, groups.length && `Grupos: ${groups.join(', ')}`]
+          .filter(Boolean)
+          .join('\n')
+      : undefined;
+  return (
+    <span className="inline-flex flex-col gap-0.5">
+      <span
+        title={title}
+        className={`inline-flex w-fit items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium ${m.cls}`}
+      >
+        <Icon size={12} />
+        {m.label}
+      </span>
+      {detail && provider === 'ldap' && (externalId || groups.length > 0) && (
+        <span className="text-[11px] leading-tight text-slate-400 font-mono break-all">
+          {externalId}
+          {groups.length > 0 && (
+            <>
+              {externalId && ' · '}
+              grupos: {groups.join(', ')}
+            </>
+          )}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/apps/web/src/pages/Profile.jsx
+++ b/apps/web/src/pages/Profile.jsx
@@ -5,6 +5,7 @@ import { AlertCircle, CheckCircle2, KeyRound, Lock } from 'lucide-react';
 import { api } from '../api.js';
 import { useAuth } from '../auth/AuthContext.jsx';
 import PageHeader from '../components/PageHeader.jsx';
+import AuthProviderBadge from '../components/AuthProviderBadge.jsx';
 
 export default function Profile() {
   const { user, refresh } = useAuth();
@@ -59,6 +60,27 @@ export default function Profile() {
           </>
         }
       />
+
+      <div className="card p-4">
+        <div className="flex items-center justify-between gap-3">
+          <div className="text-sm">
+            <div className="font-medium text-slate-700 dark:text-slate-200">Origem da conta</div>
+            <div className="text-slate-500 text-xs mt-0.5">
+              {user?.authProvider === 'ldap'
+                ? 'Sua sessão foi autenticada contra o diretório (LDAP/Active Directory).'
+                : user?.authProvider === 'oidc'
+                  ? 'Sua sessão foi autenticada via SSO (OIDC).'
+                  : 'Conta local — autenticada pelo Bagre.'}
+            </div>
+          </div>
+          <AuthProviderBadge
+            provider={user?.authProvider}
+            externalId={user?.externalId}
+            groups={user?.externalGroups}
+            detail
+          />
+        </div>
+      </div>
 
       {force && (
         <div className="card p-4 border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20">

--- a/apps/web/src/pages/Users.jsx
+++ b/apps/web/src/pages/Users.jsx
@@ -13,6 +13,7 @@ import {
 import { api, demoTryWrite } from '../api.js';
 import { useAuth } from '../auth/AuthContext.jsx';
 import PageHeader from '../components/PageHeader.jsx';
+import AuthProviderBadge from '../components/AuthProviderBadge.jsx';
 
 export default function Users() {
   const { user: me } = useAuth();
@@ -76,6 +77,7 @@ export default function Users() {
               <th className="px-3 py-2 text-left">E-mail</th>
               <th className="px-3 py-2 text-left">Nome</th>
               <th className="px-3 py-2 text-left">Perfil</th>
+              <th className="px-3 py-2 text-left">Origem</th>
               <th className="px-3 py-2 text-left">Status</th>
               <th className="px-3 py-2 text-left">Último login</th>
               <th className="px-3 py-2"></th>
@@ -98,6 +100,13 @@ export default function Users() {
                     <option value="ADMIN">ADMIN</option>
                     <option value="READER">READER</option>
                   </select>
+                </td>
+                <td className="px-3 py-2">
+                  <AuthProviderBadge
+                    provider={u.authProvider}
+                    externalId={u.externalId}
+                    groups={u.externalGroups}
+                  />
                 </td>
                 <td className="px-3 py-2">
                   {u.active ? (

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -17,6 +17,8 @@ services:
       # Login é o ÚNICO write exposto na demo → teto de brute-force bem apertado
       # (12 tentativas / 5min / IP). Em produção o default é 30 (NAT-friendly).
       LOGIN_RATE_MAX: "12"
+      # CORS travado na origem pública do demo (não refletir qualquer Origin).
+      CORS_ORIGIN: "https://demo.bagre.dev"
       DEMO_ADMIN_EMAIL: ${DEMO_ADMIN_EMAIL:-demo-admin@bagre.dev}
       DEMO_ADMIN_PASSWORD: ${DEMO_ADMIN_PASSWORD:-demo-admin}
       DEMO_READER_EMAIL: ${DEMO_READER_EMAIL:-demo-reader@bagre.dev}

--- a/infra/demo/nginx-demo.bagre.dev.conf
+++ b/infra/demo/nginx-demo.bagre.dev.conf
@@ -89,6 +89,10 @@ server {
     add_header X-Content-Type-Options nosniff always;
     add_header Referrer-Policy strict-origin-when-cross-origin always;
     add_header X-XSS-Protection "0" always;
+    # CSP — o bundle do SPA é script externo (sem inline); styles inline do React
+    # precisam de 'unsafe-inline'. Tudo same-origin; sem CDN/3rd-party.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'" always;
+    add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), payment=()" always;
 
     # Headers de proxy (válidos para todos os locations abaixo)
     proxy_set_header Host              $host;
@@ -110,6 +114,13 @@ server {
     location /api/ {
         limit_req zone=demo_api burst=40 nodelay;
         proxy_pass $demo_web;
+    }
+
+    # /metrics expõe inventário (códigos de site, nomes de subnet, utilização) sem
+    # auth. O Prometheus interno raspa pela rede Docker, não precisa do origin
+    # público — então bloqueamos aqui. (No app, /metrics continua interno.)
+    location = /metrics {
+        return 404;
     }
 
     # SPA + estáticos


### PR DESCRIPTION
## Validação de segurança do demo + selo de origem

### 🔒 Auditoria de segurança (black-box live + 3 revisões white-box)
**Veredito: demo sólido** — read-only à prova de bypass (verificado live: writes→403, no-auth→401), portas diretas da VPS fechadas, origin-lock no IP real do peer, segredos mascarados + topologia oculta, JWT fail-closed, anti LDAP-injection, sem SQLi/XSS.

**Gaps públicos corrigidos:**
- `/metrics` era público sem auth (vazava inventário) → `return 404` no nginx do demo.
- CORS refletia qualquer Origin com credentials → agora `CORS_ORIGIN` allowlist (demo fixa demo.bagre.dev).
- Falta de CSP/Permissions-Policy → adicionados no nginx.
- `/api/auth/reset` e `/change-password` sem rate-limit → adicionado.
- Banner: remove "reiniciados 04h / não insira dados reais" (read-only agora).
- Comentário enganoso no demo-guard corrigido.

### ✨ Selo de origem (LDAP/AD/SSO/Local)
Evidência visível de que o login veio do diretório: coluna "Origem" em Usuários + selo no Perfil (com DN/grupos do AD). Expõe `authProvider`/`externalId`/`externalGroups` (não-segredos).

### 📋 Backlog self-host (NÃO exploitável no demo — reportado, não corrigido aqui)
SSO callback (redirect+token na URL), SSRF allowlist em integration baseUrl, mass-assignment subnet/site PATCH, hardening de container (non-root/cap_drop), PowerDNS allow-from, JWT_SECRET no Terraform.
