### PR TITLE
security(self-host): SSO callback + SSRF (2 HIGH da auditoria)

### DIFF
--- a/apps/api/src/lib/ssrf-guard.js
+++ b/apps/api/src/lib/ssrf-guard.js
@@ -1,0 +1,70 @@
+// Guard anti-SSRF para URLs de integração configuradas por um admin
+// (Zabbix/Prometheus/PowerDNS etc.). O alvo é o vetor clássico de roubo de
+// credenciais em nuvem: apontar a integração para o endpoint de metadata
+// link-local (169.254.169.254 / fd00:ec2::254) e fazer o servidor buscá-lo.
+//
+// IMPORTANTE: faixas PRIVADAS (10/8, 172.16/12, 192.168/16) e loopback são
+// PERMITIDAS por padrão — integrações internas (Zabbix/Prometheus na rede
+// interna, em hostnames como `zabbix-web`) são o caso de uso NORMAL e não
+// podemos quebrá-las. Bloqueamos só link-local/metadata.
+// Para travar tudo (também privado/loopback), set INTEGRATION_URL_STRICT=true.
+
+import dns from 'node:dns/promises';
+import net from 'node:net';
+
+function classifyIp(ip, strict) {
+  const v = ip.replace(/^::ffff:/i, ''); // IPv4-mapped IPv6
+  if (net.isIPv4(v)) {
+    const [a, b] = v.split('.').map(Number);
+    if (a === 169 && b === 254) return 'link-local/metadata'; // 169.254.0.0/16
+    if (strict) {
+      if (a === 127) return 'loopback';
+      if (a === 0) return 'reservado';
+      if (a === 10) return 'rede privada';
+      if (a === 172 && b >= 16 && b <= 31) return 'rede privada';
+      if (a === 192 && b === 168) return 'rede privada';
+    }
+    return null;
+  }
+  const low = v.toLowerCase();
+  if (low.startsWith('fe80')) return 'link-local'; // fe80::/10
+  if (low === 'fd00:ec2::254') return 'metadata'; // AWS IMDS IPv6
+  if (strict && (low === '::1' || low.startsWith('fc') || low.startsWith('fd'))) {
+    return 'loopback/privado';
+  }
+  return null;
+}
+
+/**
+ * Lança Error se a URL apontar para um destino bloqueado. Resolve o hostname
+ * (pega todos os IPs) — pega tanto IP literal quanto nome que resolve pra
+ * metadata. Use ao SALVAR a config de integração.
+ */
+export async function assertSafeIntegrationUrl(rawUrl) {
+  let u;
+  try {
+    u = new URL(rawUrl);
+  } catch {
+    throw new Error('URL inválida');
+  }
+  if (u.protocol !== 'http:' && u.protocol !== 'https:') {
+    throw new Error('Apenas http/https são permitidos');
+  }
+  const strict = process.env.INTEGRATION_URL_STRICT === 'true';
+  const host = u.hostname.replace(/^\[|\]$/g, ''); // remove colchetes de IPv6
+
+  let ips;
+  if (net.isIP(host)) {
+    ips = [host];
+  } else {
+    try {
+      ips = (await dns.lookup(host, { all: true })).map((r) => r.address);
+    } catch {
+      throw new Error(`não foi possível resolver o host: ${host}`);
+    }
+  }
+  for (const ip of ips) {
+    const why = classifyIp(ip, strict);
+    if (why) throw new Error(`destino bloqueado (${why}): ${host} → ${ip}`);
+  }
+}

--- a/apps/api/src/routes/dns.js
+++ b/apps/api/src/routes/dns.js
@@ -7,6 +7,7 @@ import { requireAdmin } from '../auth.js';
 import { auditFromReq } from '../audit.js';
 import * as powerdns from '../integrations/dns/powerdns.js';
 import { redactForDemo } from '../demo-guard.js';
+import { assertSafeIntegrationUrl } from '../lib/ssrf-guard.js';
 
 const PROVIDERS = { powerdns };
 
@@ -52,7 +53,7 @@ export async function registerDnsRoutes(app) {
     return safeView(cfg);
   });
 
-  app.patch('/api/admin/dns-config', { preHandler: requireAdmin }, async (req) => {
+  app.patch('/api/admin/dns-config', { preHandler: requireAdmin }, async (req, reply) => {
     const body = req.body || {};
     const data = {};
     for (const f of SAFE_FIELDS) {
@@ -60,6 +61,15 @@ export async function registerDnsRoutes(app) {
     }
     if (data.apiKey && String(data.apiKey).startsWith('••••')) delete data.apiKey;
     if ('apiKey' in data && data.apiKey === '') data.apiKey = null;
+    // Anti-SSRF: rejeita URL apontando pra metadata/link-local.
+    if (data.baseUrl) {
+      try {
+        await assertSafeIntegrationUrl(data.baseUrl);
+      } catch (e) {
+        reply.code(400);
+        return { error: `URL do PowerDNS rejeitada: ${e.message}` };
+      }
+    }
     const before = await getCfg();
     const after = await prisma.dnsConfig.update({ where: { id: 1 }, data });
     await auditFromReq(req, {

--- a/apps/api/src/routes/oidc.js
+++ b/apps/api/src/routes/oidc.js
@@ -255,9 +255,45 @@ export async function registerOidcRoutes(app) {
 
     reply.clearCookie(FLOW_COOKIE, { path: '/api/auth/sso' });
 
-    // Redirect back to the SPA with the token. The SPA's /sso-callback page picks it up.
-    const next = encodeURIComponent(flow.next || '/');
-    const origin = req.headers.origin || `${req.protocol}://${req.headers.host}`.replace(/:3001$/, ':3000');
+    // Redirect back to the SPA com o token. A origem do redirect vem SEMPRE de
+    // fonte server-side confiável (env APP_BASE_URL ou a origem do redirectUri
+    // configurado) — NUNCA dos headers Origin/Host do request, senão um atacante
+    // entregaria o token recém-emitido numa origem arbitrária (open-redirect +
+    // vazamento de token). O `next` é sanitizado pra caminho local (anti
+    // open-redirect via //evil.com ou URL absoluta).
+    const origin = ssoFrontendOrigin(cfg, req);
+    const next = encodeURIComponent(safeNextPath(flow.next));
     reply.redirect(`${origin}/sso-callback?token=${token}&next=${next}`);
   });
+}
+
+// Origem do SPA pra onde devolver o token: só fontes confiáveis do servidor.
+function ssoFrontendOrigin(cfg, req) {
+  const fromEnv = process.env.APP_BASE_URL || process.env.PUBLIC_BASE_URL;
+  if (fromEnv) {
+    try {
+      return new URL(fromEnv).origin;
+    } catch {
+      /* ignore */
+    }
+  }
+  if (cfg?.redirectUri) {
+    try {
+      return new URL(cfg.redirectUri).origin;
+    } catch {
+      /* ignore */
+    }
+  }
+  // Fallback (dev): mesma origem do request. Em produção o redirectUri sempre
+  // existe (isConfigured exige), então este caminho não roda em deploy real.
+  return `${req.protocol}://${req.headers.host}`.replace(/:3001$/, ':3000');
+}
+
+// Só permite caminho local: começa com '/' e não com '//' (protocol-relative),
+// sem esquema. Qualquer outra coisa vira '/'.
+function safeNextPath(next) {
+  if (typeof next !== 'string') return '/';
+  if (!next.startsWith('/') || next.startsWith('//')) return '/';
+  if (next.includes('\\') || /^\/+\w+:/.test(next)) return '/';
+  return next;
 }

--- a/apps/api/src/routes/prometheus.js
+++ b/apps/api/src/routes/prometheus.js
@@ -7,6 +7,7 @@ import {
   syncFromPrometheus,
 } from '../integrations/prometheus.js';
 import { redactForDemo } from '../demo-guard.js';
+import { assertSafeIntegrationUrl } from '../lib/ssrf-guard.js';
 
 const SAFE_FIELDS = [
   'enabled',
@@ -42,7 +43,7 @@ export async function registerPrometheusRoutes(app) {
     return safeView(cfg);
   });
 
-  app.patch('/api/admin/prometheus-config', { preHandler: requireAdmin }, async (req) => {
+  app.patch('/api/admin/prometheus-config', { preHandler: requireAdmin }, async (req, reply) => {
     const body = req.body || {};
     const data = {};
     for (const f of SAFE_FIELDS) {
@@ -53,6 +54,15 @@ export async function registerPrometheusRoutes(app) {
     if (data.basicPassword && String(data.basicPassword).startsWith('••••')) delete data.basicPassword;
     if ('bearerToken' in data && data.bearerToken === '') data.bearerToken = null;
     if ('basicPassword' in data && data.basicPassword === '') data.basicPassword = null;
+    // Anti-SSRF: rejeita URL apontando pra metadata/link-local.
+    if (data.url) {
+      try {
+        await assertSafeIntegrationUrl(data.url);
+      } catch (e) {
+        reply.code(400);
+        return { error: `URL do Prometheus rejeitada: ${e.message}` };
+      }
+    }
     const before = await getConfig();
     const after = await prisma.prometheusConfig.update({ where: { id: 1 }, data });
     await auditFromReq(req, {

--- a/apps/api/src/routes/zabbix.js
+++ b/apps/api/src/routes/zabbix.js
@@ -8,6 +8,7 @@ import {
   invalidateSession,
 } from '../integrations/zabbix.js';
 import { stripDemoPinned, redactForDemo } from '../demo-guard.js';
+import { assertSafeIntegrationUrl } from '../lib/ssrf-guard.js';
 
 const SAFE_FIELDS = [
   'enabled',
@@ -43,7 +44,7 @@ export async function registerZabbixRoutes(app) {
     return safeView(cfg);
   });
 
-  app.patch('/api/admin/zabbix-config', { preHandler: requireAdmin }, async (req) => {
+  app.patch('/api/admin/zabbix-config', { preHandler: requireAdmin }, async (req, reply) => {
     const body = req.body || {};
     const data = {};
     for (const f of SAFE_FIELDS) {
@@ -57,6 +58,15 @@ export async function registerZabbixRoutes(app) {
     // Na demo, o alvo do Zabbix fica fixado (anti-SSRF): o visitante pode
     // alternar enabled/intervalo, mas não repointar url/credenciais.
     stripDemoPinned(data, ['url', 'username', 'password', 'apiToken']);
+    // Anti-SSRF: rejeita URL apontando pra metadata/link-local.
+    if (data.url) {
+      try {
+        await assertSafeIntegrationUrl(data.url);
+      } catch (e) {
+        reply.code(400);
+        return { error: `URL do Zabbix rejeitada: ${e.message}` };
+      }
+    }
     const before = await getConfig();
     const after = await prisma.zabbixConfig.update({ where: { id: 1 }, data });
     invalidateSession();


### PR DESCRIPTION
## Corrige os 2 riscos HIGH da auditoria (self-host)

Nenhum é exploitável no demo (SSO desligado + writes bloqueados pelo read-only), mas são reais pra quem self-hospeda a ferramenta.

### 1. SSO callback — open-redirect + vazamento de token (HIGH)
**Antes:** `oidc.js` derivava a origem do redirect dos headers `Origin`/`Host` do request e punha o JWT recém-emitido na URL → um atacante podia entregar o token numa origem arbitrária. O `next` também não era validado (open-redirect).
**Depois:** origem vem **só de fonte server-side confiável** (env `APP_BASE_URL` ou a origem do `redirectUri` configurado — nunca dos headers). `next` sanitizado pra caminho local (rejeita `//evil.com` e URL absoluta).

### 2. SSRF nas integrações (HIGH)
**Antes:** um ADMIN podia apontar a `baseUrl` de Zabbix/Prometheus/PowerDNS pra `169.254.169.254` (metadata de cloud) e o servidor buscava → roubo de credenciais de instância.
**Depois:** novo `assertSafeIntegrationUrl()` resolve o host e **bloqueia link-local/metadata** (169.254/16, fe80::/10, fd00:ec2::254) no save da config. **Faixas privadas continuam permitidas** — integração interna (Zabbix em IP privado) é o uso normal e não pode quebrar. `INTEGRATION_URL_STRICT=true` trava tudo.
Testado: bloqueia metadata/file://, permite 10.x/192.168.x.

Follow-up (não incluso): mass-assignment subnet/site PATCH, hardening de container, PowerDNS allow-from, JWT_SECRET no Terraform.
