### PR TITLE
feat(ldap): UI de configuração AD/LDAP + card em Integrações [#48 fase 3]

### DIFF
--- a/apps/api/src/routes/integrations-status.js
+++ b/apps/api/src/routes/integrations-status.js
@@ -4,6 +4,7 @@ import { testConnection as testZabbix, getConfig as getZabbixCfg, isConfigured a
 import { getConfig as getPromCfg, isConfigured as isPromConfigured } from '../integrations/prometheus.js';
 import * as powerdns from '../integrations/dns/powerdns.js';
 import { getConfig as getOidcCfg, isConfigured as isOidcConfigured, testDiscovery as testOidc } from '../auth-providers/oidc.js';
+import { getConfig as getLdapCfg, isConfigured as isLdapConfigured } from '../auth-providers/ldap.js';
 
 function ageMs(date) {
   if (!date) return null;
@@ -99,6 +100,25 @@ async function oidcStatus() {
   };
 }
 
+async function ldapStatus() {
+  const cfg = await getLdapCfg();
+  const configured = isLdapConfigured(cfg);
+  return {
+    key: 'ldap',
+    name: 'Autenticação AD/LDAP',
+    icon: '🏢',
+    description:
+      'Login com Active Directory / LDAP on-premise — papel (ADMIN/READER) mapeado pelos grupos do diretório.',
+    configured,
+    enabled: cfg.enabled,
+    lastTest: cfg.lastTestedAt
+      ? { at: cfg.lastTestedAt, ok: cfg.lastTestStatus === 'ok', message: cfg.lastTestMessage }
+      : null,
+    configUrl: '/admin/ldap',
+    healthEndpoint: '/api/admin/ldap-config/test',
+  };
+}
+
 function deriveOverall(integrations) {
   const errors = integrations.filter(
     (i) => i.enabled && (i.lastTest?.ok === false || i.lastSync?.ok === false),
@@ -125,11 +145,12 @@ function deriveOverall(integrations) {
 
 export async function registerIntegrationsStatusRoutes(app) {
   app.get('/api/admin/integrations/status', { preHandler: requireAdmin }, async () => {
-    const [zabbix, prometheus, dns, oidc, events] = await Promise.all([
+    const [zabbix, prometheus, dns, oidc, ldap, events] = await Promise.all([
       zabbixStatus(),
       prometheusStatus(),
       dnsStatus(),
       oidcStatus(),
+      ldapStatus(),
       prisma.auditLog.findMany({
         where: {
           OR: [
@@ -137,6 +158,7 @@ export async function registerIntegrationsStatusRoutes(app) {
             { entity: 'prometheus_config' },
             { entity: 'dns_config' },
             { entity: 'oidc_config' },
+            { entity: 'ldap_config' },
             { entity: 'user', action: 'login' },
           ],
         },
@@ -144,7 +166,7 @@ export async function registerIntegrationsStatusRoutes(app) {
         take: 12,
       }),
     ]);
-    const integrations = [zabbix, prometheus, dns, oidc];
+    const integrations = [zabbix, prometheus, dns, oidc, ldap];
     const overall = deriveOverall(integrations);
     return { overall, integrations, events };
   });

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -16,6 +16,7 @@ import Profile from './pages/Profile.jsx';
 import Users from './pages/Users.jsx';
 import Audit from './pages/Audit.jsx';
 import SsoSettings from './pages/SsoSettings.jsx';
+import LdapSettings from './pages/LdapSettings.jsx';
 import SsoCallback from './pages/SsoCallback.jsx';
 import ZabbixSettings from './pages/ZabbixSettings.jsx';
 import PrometheusSettings from './pages/PrometheusSettings.jsx';
@@ -96,6 +97,14 @@ export default function App() {
                   element={
                     <Protected role="ADMIN">
                       <SsoSettings />
+                    </Protected>
+                  }
+                />
+                <Route
+                  path="/admin/ldap"
+                  element={
+                    <Protected role="ADMIN">
+                      <LdapSettings />
                     </Protected>
                   }
                 />

--- a/apps/web/src/api.js
+++ b/apps/web/src/api.js
@@ -206,6 +206,12 @@ export const api = {
   testOidcConfig: () =>
     request('/admin/oidc-config/test', { method: 'POST' }),
 
+  ldapConfig: () => request('/admin/ldap-config'),
+  updateLdapConfig: (data) =>
+    request('/admin/ldap-config', { method: 'PATCH', body: JSON.stringify(data) }),
+  testLdapConfig: () =>
+    request('/admin/ldap-config/test', { method: 'POST' }),
+
   health: () => request('/health'),
   stats: () => request('/stats'),
   statsBySite: () => request('/stats/by-site'),

--- a/apps/web/src/pages/IntegrationsStatus.jsx
+++ b/apps/web/src/pages/IntegrationsStatus.jsx
@@ -11,6 +11,7 @@ import {
   Clock,
   Activity,
   Globe,
+  Building2,
   ExternalLink,
 } from 'lucide-react';
 import { api } from '../api.js';
@@ -105,6 +106,13 @@ export default function IntegrationsStatus() {
       r.ok ? toast.success(r.message) : toast.error(r.message);
     },
   });
+  const testLdap = useMutation({
+    mutationFn: api.testLdapConfig,
+    onSuccess: (r) => {
+      qc.invalidateQueries({ queryKey: ['integrations-status'] });
+      r.ok ? toast.success(r.message) : toast.error(r.message);
+    },
+  });
 
   const overall = data?.overall;
   const integrations = data?.integrations || [];
@@ -141,12 +149,14 @@ export default function IntegrationsStatus() {
               else if (i.key === 'prometheus') testPrometheus.mutate();
               else if (i.key === 'dns') testDns.mutate();
               else if (i.key === 'oidc') testOidc.mutate();
+              else if (i.key === 'ldap') testLdap.mutate();
             }}
             testing={
               (i.key === 'zabbix' && testZabbix.isPending) ||
               (i.key === 'prometheus' && testPrometheus.isPending) ||
               (i.key === 'dns' && testDns.isPending) ||
-              (i.key === 'oidc' && testOidc.isPending)
+              (i.key === 'oidc' && testOidc.isPending) ||
+              (i.key === 'ldap' && testLdap.isPending)
             }
           />
         ))}
@@ -242,6 +252,8 @@ function IntegrationLogo({ k, fallback }) {
       return <Activity size={26} strokeWidth={2.4} style={{ color: '#D40000' }} />;
     case 'dns':
       return <Globe size={26} strokeWidth={2.2} style={{ color: '#2F6FED' }} />;
+    case 'ldap':
+      return <Building2 size={26} strokeWidth={2.2} style={{ color: '#4F46E5' }} />;
     default:
       return <span className="text-2xl leading-none">{fallback}</span>;
   }

--- a/apps/web/src/pages/LdapSettings.jsx
+++ b/apps/web/src/pages/LdapSettings.jsx
@@ -1,0 +1,386 @@
+import { useEffect, useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  Server,
+  Save,
+  Activity,
+  CheckCircle2,
+  AlertCircle,
+  Power,
+} from 'lucide-react';
+import { api } from '../api.js';
+import PageHeader from '../components/PageHeader.jsx';
+import { useToast } from '../components/Toast.jsx';
+
+export default function LdapSettings() {
+  const qc = useQueryClient();
+  const toast = useToast();
+  const { data: cfg, isLoading } = useQuery({
+    queryKey: ['ldap-config'],
+    queryFn: api.ldapConfig,
+  });
+  const [form, setForm] = useState(null);
+  const [adminGroupsText, setAdminGroupsText] = useState('');
+  const [testResult, setTestResult] = useState(null);
+
+  useEffect(() => {
+    if (cfg && !form) {
+      setForm({
+        enabled: cfg.enabled,
+        url: cfg.url || '',
+        startTls: cfg.startTls ?? false,
+        bindDn: cfg.bindDn || '',
+        bindPassword: '',
+        baseDn: cfg.baseDn || '',
+        userFilter: cfg.userFilter || '(sAMAccountName={username})',
+        emailAttr: cfg.emailAttr || 'mail',
+        nameAttr: cfg.nameAttr || 'displayName',
+        groupAttr: cfg.groupAttr || 'memberOf',
+        autoProvision: cfg.autoProvision ?? true,
+        defaultRole: cfg.defaultRole || 'READER',
+      });
+      setAdminGroupsText((cfg.adminGroups || []).join('\n'));
+    }
+  }, [cfg, form]);
+
+  const save = useMutation({
+    mutationFn: api.updateLdapConfig,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['ldap-config'] });
+      qc.invalidateQueries({ queryKey: ['integrations-status'] });
+      toast.success('Configurações salvas.');
+    },
+    onError: (e) => toast.error(e.message),
+  });
+
+  const test = useMutation({
+    mutationFn: api.testLdapConfig,
+    onSuccess: (r) => {
+      setTestResult(r);
+      qc.invalidateQueries({ queryKey: ['ldap-config'] });
+      r.ok ? toast.success(r.message) : toast.error(r.message);
+    },
+    onError: (e) => {
+      setTestResult({ ok: false, message: e.message });
+      toast.error(e.message);
+    },
+  });
+
+  const enable = useMutation({
+    mutationFn: () => api.updateLdapConfig({ enabled: !form.enabled }),
+    onSuccess: (r) => {
+      qc.invalidateQueries({ queryKey: ['ldap-config'] });
+      qc.invalidateQueries({ queryKey: ['integrations-status'] });
+      setForm((f) => ({ ...f, enabled: r.enabled }));
+      toast.success(r.enabled ? 'LDAP habilitado' : 'LDAP desabilitado');
+    },
+    onError: (e) => toast.error(e.message),
+  });
+
+  if (isLoading || !form) return <p className="text-slate-500">Carregando…</p>;
+
+  const submit = (e) => {
+    e.preventDefault();
+    const data = {
+      url: form.url.trim(),
+      startTls: form.startTls,
+      bindDn: form.bindDn.trim(),
+      baseDn: form.baseDn.trim(),
+      userFilter: form.userFilter.trim(),
+      emailAttr: form.emailAttr.trim(),
+      nameAttr: form.nameAttr.trim(),
+      groupAttr: form.groupAttr.trim(),
+      autoProvision: form.autoProvision,
+      defaultRole: form.defaultRole,
+      adminGroups: adminGroupsText
+        .split(/[\n,]/)
+        .map((s) => s.trim())
+        .filter(Boolean),
+    };
+    if (form.bindPassword) data.bindPassword = form.bindPassword;
+    save.mutate(data);
+  };
+
+  const fullyConfigured =
+    cfg?.url && cfg?.bindDn && cfg?.baseDn && cfg?.hasBindPassword;
+
+  return (
+    <div className="max-w-3xl space-y-5">
+      <PageHeader
+        title="LDAP / Active Directory"
+        description="Permita que usuários entrem com as credenciais do Active Directory ou de outro servidor LDAP. O login local e o SSO continuam funcionando em paralelo (anti-lockout, caso o servidor LDAP fique fora do ar), e o papel de cada usuário vem dos grupos do AD."
+        actions={
+          <button
+            onClick={() => enable.mutate()}
+            disabled={!fullyConfigured || enable.isPending}
+            className={form.enabled ? 'btn-danger' : 'btn-primary'}
+            title={!fullyConfigured ? 'Configure a conexão antes de habilitar' : ''}
+          >
+            <Power size={14} />
+            {form.enabled ? 'Desabilitar LDAP' : 'Habilitar LDAP'}
+          </button>
+        }
+      />
+
+      <StatusBanner cfg={cfg} fullyConfigured={fullyConfigured} />
+
+      {testResult && (
+        <div
+          className={`card p-4 flex items-start gap-3 ${
+            testResult.ok
+              ? 'border-emerald-200 bg-emerald-50 dark:bg-emerald-900/20 dark:border-emerald-800'
+              : 'border-rose-200 bg-rose-50 dark:bg-rose-900/20 dark:border-rose-800'
+          }`}
+        >
+          {testResult.ok ? (
+            <CheckCircle2 size={18} className="text-emerald-600 mt-0.5" />
+          ) : (
+            <AlertCircle size={18} className="text-rose-600 mt-0.5" />
+          )}
+          <div className="text-sm">
+            <strong>{testResult.ok ? 'Conexão OK.' : 'Falha na conexão.'}</strong>{' '}
+            {testResult.message}
+          </div>
+        </div>
+      )}
+
+      <form onSubmit={submit} className="space-y-5">
+        <Section title="Conexão">
+          <Field
+            label="URL do servidor"
+            hint="Use ldaps:// para TLS direto (porta 636) ou ldap:// com StartTLS abaixo."
+          >
+            <input
+              required
+              value={form.url}
+              onChange={(e) => setForm({ ...form, url: e.target.value })}
+              placeholder="ldap://dc.corp.local:389 ou ldaps://dc.corp.local:636"
+              className="input font-mono text-xs"
+            />
+          </Field>
+          <Field>
+            <label className="inline-flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={form.startTls}
+                onChange={(e) => setForm({ ...form, startTls: e.target.checked })}
+                className="accent-brand-600"
+              />
+              StartTLS (criptografa em cima do ldap://)
+            </label>
+          </Field>
+          <Field
+            label="Conta de serviço (bind DN)"
+            hint="Conta de leitura usada para buscar usuários antes de validar a senha."
+          >
+            <input
+              required
+              value={form.bindDn}
+              onChange={(e) => setForm({ ...form, bindDn: e.target.value })}
+              placeholder="CN=svc-bagre,OU=Service,DC=corp,DC=local"
+              className="input font-mono text-xs"
+            />
+          </Field>
+          <Field
+            label="Senha da conta de serviço"
+            hint={
+              cfg?.hasBindPassword
+                ? 'Já existe uma senha salva — deixe em branco para manter a atual, ou digite uma nova para substituir.'
+                : 'Senha da conta de serviço (bind DN).'
+            }
+          >
+            <input
+              type="password"
+              value={form.bindPassword}
+              onChange={(e) => setForm({ ...form, bindPassword: e.target.value })}
+              placeholder={cfg?.hasBindPassword ? '••••••••' : ''}
+              className="input"
+            />
+          </Field>
+          <Field label="Base de busca" hint="Onde procurar os usuários na árvore.">
+            <input
+              required
+              value={form.baseDn}
+              onChange={(e) => setForm({ ...form, baseDn: e.target.value })}
+              placeholder="DC=corp,DC=local"
+              className="input font-mono text-xs"
+            />
+          </Field>
+        </Section>
+
+        <Section title="Busca de usuário">
+          <Field
+            label="Filtro de usuário"
+            hint="{username} é substituído no login. AD usa sAMAccountName; OpenLDAP costuma usar uid ou cn."
+          >
+            <input
+              required
+              value={form.userFilter}
+              onChange={(e) => setForm({ ...form, userFilter: e.target.value })}
+              placeholder="(sAMAccountName={username})"
+              className="input font-mono text-xs"
+            />
+          </Field>
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="Atributo de e-mail">
+              <input
+                value={form.emailAttr}
+                onChange={(e) => setForm({ ...form, emailAttr: e.target.value })}
+                placeholder="mail"
+                className="input font-mono text-xs"
+              />
+            </Field>
+            <Field label="Atributo de nome">
+              <input
+                value={form.nameAttr}
+                onChange={(e) => setForm({ ...form, nameAttr: e.target.value })}
+                placeholder="displayName"
+                className="input font-mono text-xs"
+              />
+            </Field>
+          </div>
+        </Section>
+
+        <Section title="Grupos e papéis">
+          <Field
+            label="Atributo de grupos"
+            hint="Atributo que lista os grupos do usuário. No AD costuma ser memberOf."
+          >
+            <input
+              value={form.groupAttr}
+              onChange={(e) => setForm({ ...form, groupAttr: e.target.value })}
+              placeholder="memberOf"
+              className="input font-mono text-xs"
+            />
+          </Field>
+          <Field
+            label="Grupos que concedem ADMIN"
+            hint="DNs de grupos que concedem ADMIN, um por linha. Ex: CN=ipam-admins,OU=Groups,DC=corp,DC=local"
+          >
+            <textarea
+              rows={3}
+              value={adminGroupsText}
+              onChange={(e) => setAdminGroupsText(e.target.value)}
+              placeholder="CN=ipam-admins,OU=Groups,DC=corp,DC=local"
+              className="input font-mono text-xs"
+            />
+          </Field>
+          <div className="grid grid-cols-2 gap-3">
+            <Field
+              label="Papel padrão"
+              hint="Papel padrão para quem não está num grupo admin."
+            >
+              <select
+                value={form.defaultRole}
+                onChange={(e) => setForm({ ...form, defaultRole: e.target.value })}
+                className="input"
+              >
+                <option value="READER">READER (somente leitura)</option>
+                <option value="ADMIN">ADMIN</option>
+              </select>
+            </Field>
+            <Field label="Provisionamento automático">
+              <label className="inline-flex items-center gap-2 text-sm pt-2">
+                <input
+                  type="checkbox"
+                  checked={form.autoProvision}
+                  onChange={(e) =>
+                    setForm({ ...form, autoProvision: e.target.checked })
+                  }
+                  className="accent-brand-600"
+                />
+                Criar o usuário automaticamente no 1º login
+              </label>
+            </Field>
+          </div>
+        </Section>
+
+        <div className="flex items-center gap-2 sticky bottom-0 bg-white/90 dark:bg-slate-900/80 backdrop-blur p-3 rounded-xl border border-slate-100 dark:border-slate-800">
+          <button type="submit" className="btn-primary" disabled={save.isPending}>
+            <Save size={14} />
+            {save.isPending ? 'Salvando…' : 'Salvar'}
+          </button>
+          <button
+            type="button"
+            onClick={() => test.mutate()}
+            className="btn-ghost"
+            disabled={test.isPending}
+          >
+            <Activity size={14} />
+            {test.isPending ? 'Testando…' : 'Testar conexão'}
+          </button>
+          {cfg?.lastTestedAt && (
+            <span className="text-xs text-slate-500 ml-auto">
+              último teste:{' '}
+              <span
+                className={
+                  cfg.lastTestStatus === 'ok' ? 'text-emerald-600' : 'text-rose-600'
+                }
+              >
+                {cfg.lastTestStatus === 'ok' ? '✓' : '✗'}{' '}
+                {new Date(cfg.lastTestedAt).toLocaleString('pt-BR')}
+              </span>
+            </span>
+          )}
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function StatusBanner({ cfg, fullyConfigured }) {
+  if (!cfg) return null;
+  if (cfg.enabled && fullyConfigured) {
+    return (
+      <div className="card p-4 border-emerald-200 bg-emerald-50 dark:bg-emerald-900/20 dark:border-emerald-800 flex items-start gap-3">
+        <CheckCircle2 size={18} className="text-emerald-600 mt-0.5" />
+        <div className="text-sm">
+          <strong>LDAP ativo.</strong> A tela de login aceita credenciais do
+          Active Directory. Login local e SSO continuam disponíveis em paralelo.
+        </div>
+      </div>
+    );
+  }
+  if (!fullyConfigured) {
+    return (
+      <div className="card p-4 border-slate-200 flex items-start gap-3">
+        <Server size={18} className="text-slate-400 mt-0.5" />
+        <div className="text-sm">
+          <strong>Não configurado.</strong> Preencha a conexão (URL, bind DN,
+          senha e base de busca) e clique em <em>Testar conexão</em>. O botão{' '}
+          <em>Habilitar LDAP</em> destrava quando os campos obrigatórios
+          estiverem preenchidos.
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="card p-4 border-amber-200 bg-amber-50 dark:bg-amber-900/20 dark:border-amber-800 flex items-start gap-3">
+      <AlertCircle size={18} className="text-amber-600 mt-0.5" />
+      <div className="text-sm">
+        <strong>Configurado, mas desabilitado.</strong> A tela de login ainda não
+        aceita credenciais do AD. Use <em>Habilitar LDAP</em> no topo desta página
+        quando estiver pronto.
+      </div>
+    </div>
+  );
+}
+
+function Section({ title, children }) {
+  return (
+    <section className="card p-5 space-y-4">
+      <h2 className="font-semibold">{title}</h2>
+      <div className="space-y-3">{children}</div>
+    </section>
+  );
+}
+
+function Field({ label, hint, children }) {
+  return (
+    <div>
+      {label && <label className="block text-sm font-medium mb-1">{label}</label>}
+      {children}
+      {hint && <p className="text-xs text-slate-500 mt-1">{hint}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
Fecha o gap apontado: o motor LDAP/AD existia mas nao tinha UI -- um self-hoster nao via como ligar o Active Directory (so via API manual).

- Card **Autenticacao AD/LDAP** na tela de Integracoes (junto de Zabbix/Prometheus/PowerDNS/SSO), com status, Testar agora e Configurar.
- Pagina **/admin/ldap** (LdapSettings): Conexao (url/StartTLS/bindDn/bindPassword/baseDn), Busca de usuario (userFilter/emailAttr/nameAttr), Grupos e papeis (groupAttr/adminGroups/autoProvision/defaultRole) + Testar conexao.
- api.js: ldapConfig/updateLdapConfig/testLdapConfig.
- Backend: ldapStatus() no agregador.

No demo o card aparece ativo (LDAP ja semeado); config read-only.
