### PR TITLE
docs(ldap): documenta autenticação LDAP/AD [#48]

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Mais prints em [`docs/screenshots/`](docs/screenshots/).
 - **Cloud sync multi-provider** — conecta AWS / Azure / GCP simultaneamente, sincroniza VPCs/VNets/subnetworks, NICs e IPs públicos. Mostra IPs ociosos sangrando custo (relatório FinOps unificado).
 - **Descoberta automática via Zabbix e Prometheus** — hosts viram pending discoveries; aprovação em 1 clique
 - API REST para integração com Terraform, scripts próprios, OTEL
-- Login local + SSO via OIDC (Microsoft Entra ID, Keycloak, qualquer provider compatível)
+- Login local + SSO via OIDC (Microsoft Entra ID, Keycloak, qualquer provider compatível) + **LDAP / Active Directory on-premise** (bind nativo, papel mapeado pelos grupos do AD)
 - RBAC com perfis ADMIN/READER e wiki integrada via DokuWiki
 - Métricas Prometheus em `/metrics`
 - Trilha de auditoria com diff antes/depois de toda alteração
@@ -107,7 +107,7 @@ A pasta [`docs/`](docs/) contém guias detalhados:
 - [`02-instalacao.md`](docs/02-instalacao.md) — Subir do zero, requisitos
 - [`03-uso-diario.md`](docs/03-uso-diario.md) — Operação pelo usuário final
 - [`04-administracao.md`](docs/04-administracao.md) — Usuários, perfis, RBAC
-- [`05-integracoes.md`](docs/05-integracoes.md) — Zabbix, OIDC, Prometheus
+- [`05-integracoes.md`](docs/05-integracoes.md) — Zabbix, SSO/OIDC, LDAP/AD, Prometheus
 - [`06-api-rest.md`](docs/06-api-rest.md) — Endpoints com exemplos `curl`
 - [`07-operacao.md`](docs/07-operacao.md) — Backup, restore, troubleshooting
 - [`08-desenvolvimento.md`](docs/08-desenvolvimento.md) — Dev local, contribuir

--- a/docs/05-integracoes.md
+++ b/docs/05-integracoes.md
@@ -188,6 +188,69 @@ O sistema é estruturado para suportar múltiplos providers no futuro (Auth0, Ke
 
 ---
 
+## Autenticação LDAP / Active Directory
+
+Login com as credenciais do **Active Directory on-premise** (ou qualquer servidor LDAP) por **bind direto** — sem precisar de broker (Keycloak/ADFS). É a paridade com phpIPAM/NetBox para quem padroniza acesso via AD.
+
+> Quando usar LDAP vs SSO/OIDC: use **LDAP/AD** se você quer que o usuário digite usuário+senha do domínio direto na tela do Bagre, contra um DC on-prem. Use **SSO/OIDC** (seção acima) para Entra ID na nuvem ou login federado com redirect. Os dois podem coexistir com o login local.
+
+### Como funciona
+
+1. O Bagre conecta com uma **conta de serviço** (bind DN) e **busca** o usuário pelo filtro (ex.: `sAMAccountName`).
+2. Faz um **re-bind como o próprio usuário** com a senha digitada — é assim que a credencial é validada (não há comparação de hash; quem valida é o AD).
+3. Lê os **grupos** do usuário (`memberOf`) e mapeia para papel **ADMIN** ou **READER**.
+4. No 1º login, **provisiona** o usuário local espelhando o AD (`authProvider=ldap`).
+
+### Configuração passo a passo
+
+1. Sidebar → **Integrações** → card **Autenticação AD/LDAP** → **Configurar** (`/admin/ldap`).
+2. **Seção Conexão:**
+   - **URL**: `ldap://dc.corp.local:389` (ou `ldaps://dc.corp.local:636` para TLS).
+   - **StartTLS**: marque se for usar `ldap://` na porta 389 com upgrade para TLS (alternativa ao `ldaps://`). Em produção, **use LDAPS ou StartTLS** — sem isso a senha trafega em claro.
+   - **Bind DN** (conta de serviço): `CN=svc-bagre,OU=Service,DC=corp,DC=local`.
+   - **Senha do bind**: a senha da conta de serviço (fica mascarada; nunca é devolvida crua à UI).
+   - **Base DN**: `DC=corp,DC=local`.
+3. **Seção Busca de usuário:**
+   - **Filtro**: `(sAMAccountName={username})` para AD. Em OpenLDAP costuma ser `(uid={username})` ou `(cn={username})`. O `{username}` é substituído pelo que o usuário digita (com escape anti-injection).
+   - **Atributo de e-mail** / **nome**: `mail` / `displayName` (padrões do AD).
+4. **Seção Grupos e papéis:**
+   - **Atributo de grupos**: `memberOf` (padrão do AD).
+   - **Grupos que concedem ADMIN**: os **DNs** dos grupos, um por linha. Ex.: `CN=ipam-admins,OU=Groups,DC=corp,DC=local`. Membros viram ADMIN; os demais recebem o papel padrão.
+   - **Papel padrão**: READER.
+   - **Provisionar automaticamente**: marcado (cria o usuário no 1º login).
+5. Clique **Testar conexão** → deve responder "OK — conectou em ldap://…".
+6. Marque **Habilitar** e salve.
+
+A partir daí, a tela de login aceita usuário+senha do domínio. (No demo público a config aparece preenchida como exemplo, com a senha mascarada.)
+
+### Comportamento e precedência
+
+- **Precedência de login**: local → **LDAP** → OIDC. O login local e o SSO continuam funcionando em paralelo (**anti-lockout**: se o servidor LDAP cair, o admin local ainda entra).
+- **1º login**: cria o usuário com papel mapeado pelos grupos. **Logins seguintes**: revalidam grupos/papel.
+- **Auditoria**: cada login gera entrada no AuditLog.
+
+### Segurança
+
+- Senha do service account **mascarada** em respostas e logs (a API só devolve `hasBindPassword`).
+- **Anti LDAP-injection**: o `{username}` é escapado conforme RFC 4515.
+- **Rejeita senha vazia** (evita o "bind anônimo bem-sucedido" que viraria bypass de autenticação).
+- A busca deve retornar **exatamente um** usuário, senão o login é negado.
+
+### Troubleshoot
+
+| Sintoma | Causa provável |
+|---|---|
+| "Testar conexão" falha com timeout | URL/porta errada, firewall, ou o DC não aceita a porta informada |
+| Conecta mas todo login dá 401 | filtro de busca errado (ex.: `uid` num AD que usa `sAMAccountName`), ou Base DN não cobre os usuários |
+| Login OK mas usuário não vira ADMIN | DN do grupo em "Grupos ADMIN" não bate **exatamente** com o `memberOf` (compare o DN completo, case-insensitive) |
+| "socket disconnected before TLS" | usou `ldaps://` num servidor que só fala `ldap://` (ou vice-versa); confira porta 389 vs 636 e a opção StartTLS |
+
+### Ambiente de testes local (sem AD real)
+
+O overlay do demo sobe um **OpenLDAP** (slapd) a partir da imagem oficial do Debian, com schema estilo AD (`sAMAccountName` + overlay `memberOf`) e usuários `alice`/`bob`. Veja `infra/demo/openldap/` e `docker-compose.demo.yml`. Útil para validar a integração de ponta a ponta antes de plugar no DC de verdade.
+
+---
+
 ## Ingestão externa (scanners, OTEL, scripts)
 
 Para atualizar o IPAM a partir de **qualquer ferramenta externa** sem precisar de uma conta de usuário, use os endpoints de ingestão.


### PR DESCRIPTION
Seção completa de LDAP/Active Directory em docs/05-integracoes.md + menções no README. Fecha o último item (doc) do checklist da #48.
