### PR TITLE
feat(ldap): LDAPS pronto pra produção corporativa (validação + CA interna) [#48]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Mudanças que estão em `main` e ainda não entraram em release oficial.
 - **Rate-limit** de login configurável (`LOGIN_RATE_MAX`; demo fixa 12/5min) e estendido a `/api/auth/reset` e `/change-password`.
 - **SSO callback:** a origem do redirect passa a vir de fonte server-side confiável (`APP_BASE_URL`/`redirectUri`), não dos headers do request, e o `next` é sanitizado — corrige open-redirect e vazamento de token na URL.
 - **Anti-SSRF nas integrações:** ao salvar a URL de Zabbix/Prometheus/PowerDNS, destinos **link-local/metadata** (`169.254.0.0/16`, `fd00:ec2::254`) são bloqueados; redes privadas internas continuam permitidas (`INTEGRATION_URL_STRICT=true` trava tudo).
+- **LDAPS pronto pra produção corporativa:** validação de certificado **ON por padrão**, com campo pra colar a **CA interna do AD (AD CS)** em PEM — valida o LDAPS sem desligar a checagem (ou via `NODE_EXTRA_CA_CERTS`). Toggle explícito (com aviso) pra relaxar validação em lab, e aviso quando se usa `ldap://` sem TLS. Autenticação AD validada de ponta a ponta contra um **Samba AD DC** (LDAPS com cert validado pela CA).
 
 ---
 

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -189,6 +189,10 @@ model LdapConfig {
   enabled         Boolean   @default(false)
   url             String? // ldap://host:389 ou ldaps://host:636
   startTls        Boolean   @default(false) // StartTLS em cima do ldap:// (alternativa ao ldaps://)
+  // TLS: validação ON por padrão (boa prática). caCert permite confiar na CA
+  // interna do AD (AD CS) SEM desligar a validação — o jeito seguro on-premise.
+  tlsRejectUnauthorized Boolean @default(true) // false = NÃO valida o cert (inseguro, só lab)
+  caCert          String? // PEM da CA que assina o cert do LDAPS (cert público, não é segredo)
   bindDn          String? // service account p/ buscar usuários (ex: CN=svc-bagre,OU=svc,DC=corp,DC=local)
   bindPassword    String? // senha do service account — nunca retornada crua à UI
   baseDn          String? // base de busca (ex: DC=corp,DC=local)

--- a/apps/api/src/auth-providers/ldap.js
+++ b/apps/api/src/auth-providers/ldap.js
@@ -32,14 +32,27 @@ function escapeFilter(value) {
   );
 }
 
+// Opções de TLS — usadas tanto em ldaps:// (no construtor) quanto no StartTLS.
+//  - rejectUnauthorized: valida o cert do servidor. ON por padrão (boa prática).
+//    Só vira false se o admin explicitamente desligar (lab/ins=eguro).
+//  - ca: confia numa CA específica (a CA interna do AD/AD CS) sem desligar a
+//    validação — é o caminho SEGURO pra LDAPS on-premise com cert de CA própria.
+//    O Node também aceita NODE_EXTRA_CA_CERTS como alternativa via env.
+function buildTlsOptions(cfg) {
+  const opts = { rejectUnauthorized: cfg.tlsRejectUnauthorized !== false };
+  if (cfg.caCert && String(cfg.caCert).trim()) {
+    opts.ca = [String(cfg.caCert)];
+  }
+  return opts;
+}
+
 function makeClient(cfg) {
   const opts = { url: cfg.url, timeout: 8000, connectTimeout: 8000 };
   // tlsOptions SÓ pra ldaps:// — passar em ldap:// faz o ldapts tentar um
   // handshake TLS que o servidor recusa ("socket disconnected before TLS").
-  // No StartTLS o cert é validado no client.startTLS() (ver withClient).
-  // Cert validado por padrão; AD com CA interna precisará fornecer a CA (futuro).
+  // No StartTLS o TLS é negociado no client.startTLS() (ver withClient).
   if ((cfg.url || '').startsWith('ldaps://')) {
-    opts.tlsOptions = { rejectUnauthorized: true };
+    opts.tlsOptions = buildTlsOptions(cfg);
   }
   return new Client(opts);
 }
@@ -47,7 +60,7 @@ function makeClient(cfg) {
 async function withClient(cfg, fn) {
   const client = makeClient(cfg);
   try {
-    if (cfg.startTls) await client.startTLS({ rejectUnauthorized: true });
+    if (cfg.startTls) await client.startTLS(buildTlsOptions(cfg));
     return await fn(client);
   } finally {
     try {

--- a/apps/api/src/routes/ldap.js
+++ b/apps/api/src/routes/ldap.js
@@ -30,6 +30,8 @@ export async function registerLdapRoutes(app) {
       'enabled',
       'url',
       'startTls',
+      'tlsRejectUnauthorized',
+      'caCert',
       'bindDn',
       'baseDn',
       'userFilter',

--- a/apps/web/src/pages/LdapSettings.jsx
+++ b/apps/web/src/pages/LdapSettings.jsx
@@ -29,6 +29,8 @@ export default function LdapSettings() {
         enabled: cfg.enabled,
         url: cfg.url || '',
         startTls: cfg.startTls ?? false,
+        tlsRejectUnauthorized: cfg.tlsRejectUnauthorized ?? true,
+        caCert: cfg.caCert || '',
         bindDn: cfg.bindDn || '',
         bindPassword: '',
         baseDn: cfg.baseDn || '',
@@ -84,6 +86,8 @@ export default function LdapSettings() {
     const data = {
       url: form.url.trim(),
       startTls: form.startTls,
+      tlsRejectUnauthorized: form.tlsRejectUnauthorized,
+      caCert: form.caCert.trim() || null,
       bindDn: form.bindDn.trim(),
       baseDn: form.baseDn.trim(),
       userFilter: form.userFilter.trim(),
@@ -169,6 +173,50 @@ export default function LdapSettings() {
               StartTLS (criptografa em cima do ldap://)
             </label>
           </Field>
+
+          {form.url.startsWith('ldap://') && !form.startTls && (
+            <p className="text-xs rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-amber-800 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-200">
+              ⚠️ Sem TLS: a senha do usuário trafega em texto claro, e ADs modernos
+              recusam bind sem criptografia. Em produção use <code>ldaps://</code> (porta
+              636) ou marque StartTLS.
+            </p>
+          )}
+
+          {(form.url.startsWith('ldaps://') || form.startTls) && (
+            <>
+              <Field>
+                <label className="inline-flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={form.tlsRejectUnauthorized}
+                    onChange={(e) =>
+                      setForm({ ...form, tlsRejectUnauthorized: e.target.checked })
+                    }
+                    className="accent-brand-600"
+                  />
+                  Validar o certificado do servidor (recomendado)
+                </label>
+                {!form.tlsRejectUnauthorized && (
+                  <p className="mt-1 text-xs text-rose-600 dark:text-rose-400">
+                    ⚠️ Validação desligada — exposto a man-in-the-middle. Use só em
+                    laboratório; em produção, forneça a CA abaixo.
+                  </p>
+                )}
+              </Field>
+              <Field
+                label="Certificado da CA (PEM)"
+                hint="Cole a CA que assina o cert do LDAPS do seu AD (ex.: a CA raiz do AD CS). Necessário quando o cert não vem de uma CA pública — assim o LDAPS valida sem desligar a checagem. Alternativa: a env NODE_EXTRA_CA_CERTS no container da API."
+              >
+                <textarea
+                  rows={4}
+                  value={form.caCert}
+                  onChange={(e) => setForm({ ...form, caCert: e.target.value })}
+                  placeholder={'-----BEGIN CERTIFICATE-----\n…\n-----END CERTIFICATE-----'}
+                  className="input font-mono text-xs"
+                />
+              </Field>
+            </>
+          )}
           <Field
             label="Conta de serviço (bind DN)"
             hint="Conta de leitura usada para buscar usuários antes de validar a senha."

--- a/docs/05-integracoes.md
+++ b/docs/05-integracoes.md
@@ -223,6 +223,23 @@ Login com as credenciais do **Active Directory on-premise** (ou qualquer servido
 
 A partir daí, a tela de login aceita usuário+senha do domínio. (No demo público a config aparece preenchida como exemplo, com a senha mascarada.)
 
+### LDAPS em produção (criptografia + certificado)
+
+Em produção **não use `ldap://` puro** — a senha do usuário trafega em texto claro e **um AD endurecido recusa o bind sem criptografia** ("Strong(er) authentication required"). Use **`ldaps://` (porta 636)** ou marque **StartTLS**.
+
+O detalhe que trava a maioria: o LDAPS do AD on-premise costuma usar um **certificado emitido pela CA interna** (AD CS), que o Bagre (corretamente) **não confia por padrão**. Há duas formas seguras de resolver — **sem desligar a validação**:
+
+1. **Pela tela (recomendado):** com `ldaps://`/StartTLS selecionado, aparecem dois campos:
+   - **Validar o certificado do servidor** — deixe **marcado** (padrão).
+   - **Certificado da CA (PEM)** — cole a **CA raiz do seu AD CS** (o cert público que assina o cert do DC). Pronto: o LDAPS valida contra a sua CA.
+2. **Por variável de ambiente** (alternativa, útil em IaC): monte o PEM da CA no container da API e aponte `NODE_EXTRA_CA_CERTS=/certs/ad-ca.pem`. O Node passa a confiar nela em todo TLS.
+
+> **Desligar a validação** (`Validar certificado` desmarcado / `rejectUnauthorized=false`) existe só para **laboratório** — deixa a conexão vulnerável a man-in-the-middle. Em produção, forneça a CA.
+
+Validado de ponta a ponta contra um **Samba AD DC**: com a CA correta o LDAPS valida e autentica; **sem** a CA, a conexão é corretamente recusada (`unable to verify the first certificate`).
+
+> **Hostname:** a URL (`ldaps://dc1.corp.local:636`) precisa bater com o **CN/SAN** do certificado do DC. Use o FQDN do controlador, não o IP.
+
 ### Comportamento e precedência
 
 - **Precedência de login**: local → **LDAP** → OIDC. O login local e o SSO continuam funcionando em paralelo (**anti-lockout**: se o servidor LDAP cair, o admin local ainda entra).
@@ -244,6 +261,9 @@ A partir daí, a tela de login aceita usuário+senha do domínio. (No demo públ
 | Conecta mas todo login dá 401 | filtro de busca errado (ex.: `uid` num AD que usa `sAMAccountName`), ou Base DN não cobre os usuários |
 | Login OK mas usuário não vira ADMIN | DN do grupo em "Grupos ADMIN" não bate **exatamente** com o `memberOf` (compare o DN completo, case-insensitive) |
 | "socket disconnected before TLS" | usou `ldaps://` num servidor que só fala `ldap://` (ou vice-versa); confira porta 389 vs 636 e a opção StartTLS |
+| `unable to verify the first certificate` (LDAPS) | a CA interna do AD não é confiável pelo Bagre — cole a CA no campo **Certificado da CA (PEM)** (ou use `NODE_EXTRA_CA_CERTS`) |
+| `Strong(er) authentication required` / `Transport encryption required` | o AD recusa bind sem TLS — use `ldaps://` (636) ou StartTLS |
+| `ERR_TLS_CERT_ALTNAME_INVALID` | a URL não bate com o CN/SAN do cert — use o **FQDN** do DC, não o IP |
 
 ### Ambiente de testes local (sem AD real)
 


### PR DESCRIPTION
Prepara o AD on-premise pra boas práticas de segurança corporativa.

## O quê
- **Validação de certificado ON por padrão** (rejectUnauthorized=true), aplicada a `ldaps://` E StartTLS via `buildTlsOptions()`.
- **Campo `Certificado da CA (PEM)`**: confia na CA interna do AD (AD CS) **sem desligar a validação** — o jeito seguro on-prem. Alternativa: `NODE_EXTRA_CA_CERTS`.
- **Toggle 'validar certificado'** (com aviso quando desligado) + aviso quando se usa `ldap://` sem TLS.
- Schema: `LdapConfig.tlsRejectUnauthorized` (default true) + `caCert` (aplicado no boot via `prisma db push`).
- Doc: seção 'LDAPS em produção' + troubleshoot.

## Validado de fato
End-to-end contra um **Samba AD DC real**:
- LDAPS + CA correta → autentica (alice ADMIN via grupo) ✅
- sem CA → recusa (`unable to verify the first certificate`) ✅ — validação é real.
