### PR TITLE
chore(web): node:22-alpine no Dockerfile (requisito do vite 8)

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:20-alpine AS deps
+FROM node:22-alpine AS deps
 WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm install
 
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .


### PR DESCRIPTION
Vite 8 exige Node ^20.19 || >=22.12. Fixa o Dockerfile da web em node:22-alpine pra o build não quebrar na VPS com uma tag node:20 antiga.