### PR TITLE
feat(ansible): Ansible Collection bagre.ipam

### DIFF
--- a/.github/workflows/ansible-collection.yml
+++ b/.github/workflows/ansible-collection.yml
@@ -1,0 +1,57 @@
+name: Ansible Collection (bagre.ipam)
+
+on:
+  push:
+    branches: [main]
+    paths: ['ansible/**', '.github/workflows/ansible-collection.yml']
+    tags: ['ansible-v*']
+  pull_request:
+    paths: ['ansible/**', '.github/workflows/ansible-collection.yml']
+
+jobs:
+  sanity:
+    name: Build + Sanity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Instala ansible-core
+        run: pip install ansible-core
+
+      - name: Coloca a collection no layout esperado
+        run: |
+          mkdir -p "${{ runner.temp }}/ansible_collections/bagre/ipam"
+          cp -r ansible/. "${{ runner.temp }}/ansible_collections/bagre/ipam/"
+
+      - name: Build da collection
+        working-directory: ${{ runner.temp }}/ansible_collections/bagre/ipam
+        run: ansible-galaxy collection build --output-path /tmp/build
+
+      - name: Sanity tests
+        working-directory: ${{ runner.temp }}/ansible_collections/bagre/ipam
+        run: ansible-test sanity --venv --python 3.11
+
+  publish:
+    name: Publica no Ansible Galaxy
+    needs: sanity
+    if: startsWith(github.ref, 'refs/tags/ansible-v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install ansible-core
+      - name: Build
+        working-directory: ansible
+        run: ansible-galaxy collection build --output-path /tmp/build
+      - name: Publish
+        env:
+          GALAXY_TOKEN: ${{ secrets.ANSIBLE_GALAXY_TOKEN }}
+        run: |
+          ansible-galaxy collection publish /tmp/build/bagre-ipam-*.tar.gz \
+            --api-key "$GALAXY_TOKEN"

--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -1,0 +1,7 @@
+# Python
+__pycache__/
+*.py[cod]
+
+# Artefatos de build da collection
+*.tar.gz
+tests/output/

--- a/ansible/COPYING
+++ b/ansible/COPYING
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,112 @@
+# Ansible Collection — `bagre.ipam`
+
+Automatize o [Bagre IPAM](https://bagre.dev) com Ansible: gerencie sites, subnets,
+IPs, devices, faixas corporativas, regras de validação e contas cloud — além de um
+**inventário dinâmico** e um **lookup de próximo IP livre**.
+
+> Faz par com o [`terraform-provider-bagre`](https://github.com/fabgcruz/terraform-provider-bagre):
+> IaC via Terraform, automação operacional via Ansible.
+
+## Requisitos
+
+- `ansible-core` >= 2.15
+- Um Bagre acessível e um **token de API** (`bagre_...`) com escopo `READ_WRITE`
+  (crie em *Administração → API Tokens* ou via `POST /api/api-tokens`).
+
+## Instalação
+
+```bash
+ansible-galaxy collection install bagre.ipam
+```
+
+## Configuração
+
+Todos os módulos aceitam `endpoint` e `token`, ou as variáveis de ambiente:
+
+```bash
+export BAGRE_ENDPOINT=https://ipam.example.com
+export BAGRE_TOKEN=bagre_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+## Conteúdo
+
+### Módulos
+
+| Módulo | O que faz |
+|--------|-----------|
+| `bagre.ipam.site` | Cria/atualiza/remove sites (locais/datacenters) |
+| `bagre.ipam.subnet` | Cria/atualiza/remove subnets (CIDR) |
+| `bagre.ipam.ip` | Reserva/libera/atualiza um IP |
+| `bagre.ipam.device` | Cria/atualiza/remove devices (hosts) |
+| `bagre.ipam.master_range` | Gerencia faixas corporativas |
+| `bagre.ipam.validation_rule` | Gerencia regras de validação de subnets |
+| `bagre.ipam.cloud_account` | Gerencia contas AWS/Azure/GCP |
+| `bagre.ipam.next_free_ip` | Retorna o próximo IP livre de uma subnet |
+| `*_info` | Versões somente-leitura: `site_info`, `subnet_info`, `device_info`, `ip_info` |
+
+### Plugins
+
+| Plugin | Tipo | O que faz |
+|--------|------|-----------|
+| `bagre.ipam.bagre` | inventory | Inventário dinâmico a partir dos IPs do Bagre |
+| `bagre.ipam.next_free_ip` | lookup | Próximo IP livre dentro de uma expressão Jinja |
+
+> **Fora do escopo (por design):** gestão de usuários e de tokens de API não é
+> exposta — a API do Bagre bloqueia esses endpoints para tokens de automação
+> (só admin autenticado via UI/JWT).
+
+## Exemplo rápido
+
+```yaml
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Garante o site DC1
+      bagre.ipam.site:
+        code: DC1
+        name: Data Center 1
+
+    - name: Garante a subnet de produção
+      bagre.ipam.subnet:
+        site_id: 1
+        name: LAN-PROD
+        cidr: 10.150.5.0/24
+        vlan_id: 510
+
+    - name: Reserva o próximo IP livre
+      bagre.ipam.ip:
+        subnet_cidr: 10.150.5.0/24
+        address: "{{ lookup('bagre.ipam.next_free_ip', '10.150.5.0/24') }}"
+        hostname: srv-web-01
+        function: Web
+        state: reserved
+```
+
+Veja mais em [`playbooks/`](playbooks/).
+
+## Inventário dinâmico
+
+```yaml
+# inventory.bagre.yml
+plugin: bagre.ipam.bagre
+endpoint: https://ipam.example.com
+statuses: [USED, RESERVED]
+keyed_groups:
+  - key: bagre_site
+    prefix: site
+compose:
+  ansible_host: bagre_address
+```
+
+```bash
+ansible-inventory -i inventory.bagre.yml --graph
+```
+
+Cada IP com `hostname` vira um host; grupos `site_*` e `func_*` são criados
+automaticamente. Variáveis por host: `bagre_address`, `bagre_status`,
+`bagre_type`, `bagre_function`, `bagre_site`, `bagre_subnet`, `bagre_mac`.
+
+## Licença
+
+GPL-3.0-or-later © Fabricio Cruz (padrão das collections Ansible; veja `COPYING`).
+O produto Bagre em si permanece sob licença MIT.

--- a/ansible/changelogs/changelog.yaml
+++ b/ansible/changelogs/changelog.yaml
@@ -1,0 +1,9 @@
+ancestor: null
+releases:
+  1.0.0:
+    release_date: '2026-07-29'
+    changes:
+      release_summary: >-
+        Primeira versão da collection bagre.ipam — módulos para sites, subnets,
+        IPs, devices, master ranges, regras de validação e contas cloud, além do
+        inventário dinâmico e do lookup de próximo IP livre.

--- a/ansible/galaxy.yml
+++ b/ansible/galaxy.yml
@@ -1,0 +1,28 @@
+namespace: bagre
+name: ipam
+version: 1.0.0
+readme: README.md
+authors:
+  - Fabricio Cruz (@fabgcruz)
+description: >-
+  Automatize o Bagre IPAM com Ansible — gerencie sites, subnets, IPs, devices,
+  master ranges, regras de validação, contas cloud e usuários, além de um
+  inventário dinâmico e um lookup de próximo IP livre.
+license:
+  - GPL-3.0-or-later
+tags:
+  - bagre
+  - ipam
+  - networking
+  - ipaddress
+  - infrastructure
+  - cloud
+  - devops
+repository: https://github.com/fabgcruz/bagre
+documentation: https://github.com/fabgcruz/bagre/tree/main/ansible
+homepage: https://bagre.dev
+issues: https://github.com/fabgcruz/bagre/issues
+build_ignore:
+  - .github
+  - tests/output
+  - "*.tar.gz"

--- a/ansible/meta/runtime.yml
+++ b/ansible/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: ">=2.15.0"

--- a/ansible/playbooks/exemplo.yml
+++ b/ansible/playbooks/exemplo.yml
@@ -1,0 +1,42 @@
+---
+# Exemplo de uso da collection bagre.ipam
+# Rode com:
+#   export BAGRE_ENDPOINT=https://ipam.example.com
+#   export BAGRE_TOKEN=bagre_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+#   ansible-playbook playbooks/exemplo.yml
+- name: Provisiona rede no Bagre IPAM
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Garante o site DC1
+      bagre.ipam.site:
+        code: DC1
+        name: Data Center 1
+        state: present
+      register: site
+
+    - name: Garante a subnet de produção
+      bagre.ipam.subnet:
+        site_id: "{{ site.resource.id }}"
+        name: LAN-PROD
+        cidr: 10.150.5.0/24
+        vlan_id: 510
+        state: present
+
+    - name: Descobre o próximo IP livre
+      bagre.ipam.next_free_ip:
+        subnet_cidr: 10.150.5.0/24
+      register: livre
+
+    - name: Reserva e nomeia esse IP
+      bagre.ipam.ip:
+        subnet_cidr: 10.150.5.0/24
+        address: "{{ livre.ip.address }}"
+        hostname: srv-web-01
+        type: Servidor
+        function: Web
+        state: present
+
+    - name: Mostra o resultado
+      ansible.builtin.debug:
+        msg: "IP {{ livre.ip.address }} atribuído a srv-web-01"

--- a/ansible/playbooks/inventory.bagre.yml
+++ b/ansible/playbooks/inventory.bagre.yml
@@ -1,0 +1,16 @@
+---
+# Exemplo de inventário dinâmico do Bagre.
+# Uso:
+#   export BAGRE_TOKEN=bagre_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+#   ansible-inventory -i playbooks/inventory.bagre.yml --graph
+plugin: bagre.ipam.bagre
+endpoint: https://ipam.example.com
+# token vem da variável de ambiente BAGRE_TOKEN
+statuses:
+  - USED
+  - RESERVED
+keyed_groups:
+  - key: bagre_type
+    prefix: tipo
+compose:
+  ansible_host: bagre_address

--- a/ansible/plugins/doc_fragments/bagre.py
+++ b/ansible/plugins/doc_fragments/bagre.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, Fabricio Cruz (@fabgcruz)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+    # Opções de conexão comuns a todos os módulos da collection bagre.ipam
+    DOCUMENTATION = r'''
+options:
+  endpoint:
+    description:
+      - URL base da API do Bagre, ex. C(https://ipam.example.com).
+      - Pode ser definida pela variável de ambiente E(BAGRE_ENDPOINT).
+    type: str
+    required: true
+  token:
+    description:
+      - Token de API do Bagre (formato C(bagre_...)), com escopo C(READ_WRITE)
+        para operações de escrita.
+      - Pode ser definido pela variável de ambiente E(BAGRE_TOKEN).
+    type: str
+    required: true
+  validate_certs:
+    description:
+      - Se V(false), não valida o certificado TLS do endpoint.
+    type: bool
+    default: true
+  timeout:
+    description:
+      - Tempo limite (segundos) das requisições HTTP.
+    type: int
+    default: 30
+'''

--- a/ansible/plugins/inventory/bagre.py
+++ b/ansible/plugins/inventory/bagre.py
@@ -1,0 +1,166 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, Fabricio Cruz (@fabgcruz)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+name: bagre
+author: Fabricio Cruz (@fabgcruz)
+version_added: "1.0.0"
+short_description: Inventário dinâmico do Bagre IPAM
+description:
+  - Constrói o inventário do Ansible a partir dos IPs cadastrados no Bagre.
+  - Cada IP com hostname vira um host; o endereço vira C(ansible_host).
+  - Agrupa automaticamente por site, subnet, tipo e função, e suporta
+    O(compose), O(groups) e O(keyed_groups).
+extends_documentation_fragment:
+  - constructed
+  - inventory_cache
+options:
+  plugin:
+    description: Marcador do plugin; deve ser V(bagre.ipam.bagre).
+    required: true
+    choices: [bagre.ipam.bagre]
+  endpoint:
+    description: URL base da API do Bagre.
+    type: str
+    required: true
+    env:
+      - name: BAGRE_ENDPOINT
+  token:
+    description: Token de API do Bagre (C(bagre_...)).
+    type: str
+    required: true
+    env:
+      - name: BAGRE_TOKEN
+  validate_certs:
+    description: Valida o certificado TLS.
+    type: bool
+    default: true
+  timeout:
+    description: Timeout HTTP em segundos.
+    type: int
+    default: 30
+  statuses:
+    description: Quais status de IP incluir no inventário.
+    type: list
+    elements: str
+    default: [USED]
+  hostname_var:
+    description:
+      - Qual campo do IP usar como nome do host (C(hostname) por padrão).
+      - Se o IP não tiver esse campo preenchido, ele é ignorado.
+    type: str
+    default: hostname
+'''
+
+EXAMPLES = r'''
+# arquivo: inventory.bagre.yml
+plugin: bagre.ipam.bagre
+endpoint: https://ipam.example.com
+# token via variável de ambiente BAGRE_TOKEN
+statuses:
+  - USED
+  - RESERVED
+keyed_groups:
+  - key: bagre_site
+    prefix: site
+  - key: bagre_function
+    prefix: func
+compose:
+  ansible_host: bagre_address
+'''
+
+from ansible.errors import AnsibleError
+from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
+from ansible.module_utils.common.text.converters import to_native
+from ansible_collections.bagre.ipam.plugins.module_utils.bagre import (
+    BagreClient, BagreError,
+)
+
+
+class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
+
+    NAME = 'bagre.ipam.bagre'
+
+    def verify_file(self, path):
+        if not super(InventoryModule, self).verify_file(path):
+            return False
+        return path.endswith(('bagre.yml', 'bagre.yaml',
+                              'bagre_inventory.yml', 'bagre_inventory.yaml'))
+
+    def _fetch_hosts(self, client, statuses):
+        """Retorna [(hostname, host_vars_dict), ...] a partir dos IPs do Bagre."""
+        hosts = []
+        sites = client.get('/sites') or []
+        for site in sites:
+            site_code = site.get('code')
+            for subnet in site.get('subnets', []) or []:
+                sn_id = subnet.get('id')
+                ips = client.get('/subnets/{0}/ips'.format(sn_id)) or []
+                for ip in ips:
+                    if statuses and ip.get('status') not in statuses:
+                        continue
+                    hostvars = {
+                        'bagre_address': ip.get('address'),
+                        'bagre_status': ip.get('status'),
+                        'bagre_type': ip.get('type'),
+                        'bagre_function': ip.get('function'),
+                        'bagre_mac': ip.get('macAddress'),
+                        'bagre_site': site_code,
+                        'bagre_subnet': subnet.get('cidr'),
+                        'bagre_notes': ip.get('notes'),
+                    }
+                    hosts.append((ip, hostvars))
+        return hosts
+
+    def parse(self, inventory, loader, path, cache=True):
+        super(InventoryModule, self).parse(inventory, loader, path, cache=cache)
+        self._read_config_data(path)
+
+        hostname_var = self.get_option('hostname_var')
+        statuses = self.get_option('statuses')
+
+        client = BagreClient(
+            endpoint=self.get_option('endpoint'),
+            token=self.get_option('token'),
+            validate_certs=self.get_option('validate_certs'),
+            timeout=self.get_option('timeout'),
+        )
+
+        try:
+            raw_hosts = self._fetch_hosts(client, statuses)
+        except BagreError as e:
+            raise AnsibleError(to_native(e))
+
+        strict = self.get_option('strict')
+
+        for ip, hostvars in raw_hosts:
+            name = ip.get(hostname_var)
+            if not name:
+                continue
+            self.inventory.add_host(name)
+            for k, v in hostvars.items():
+                self.inventory.set_variable(name, k, v)
+
+            # grupos automáticos por site e subnet
+            if hostvars['bagre_site']:
+                grp = self.inventory.add_group('site_%s' % self._sanitize(hostvars['bagre_site']))
+                self.inventory.add_child(grp, name)
+            if hostvars['bagre_function']:
+                grp = self.inventory.add_group('func_%s' % self._sanitize(hostvars['bagre_function']))
+                self.inventory.add_child(grp, name)
+
+            # constructable: compose / groups / keyed_groups definidos pelo usuário
+            self._set_composite_vars(self.get_option('compose'), hostvars, name, strict=strict)
+            self._add_host_to_composed_groups(self.get_option('groups'), hostvars, name, strict=strict)
+            self._add_host_to_keyed_groups(self.get_option('keyed_groups'), hostvars, name, strict=strict)
+
+    @staticmethod
+    def _sanitize(value):
+        out = []
+        for ch in to_native(value):
+            out.append(ch if (ch.isalnum() or ch == '_') else '_')
+        return ''.join(out)

--- a/ansible/plugins/lookup/next_free_ip.py
+++ b/ansible/plugins/lookup/next_free_ip.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, Fabricio Cruz (@fabgcruz)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+name: next_free_ip
+author: Fabricio Cruz (@fabgcruz)
+version_added: "1.0.0"
+short_description: Retorna o próximo IP livre de uma ou mais subnets do Bagre
+description:
+  - Recebe CIDRs de subnets como termos e retorna o próximo IP livre de cada uma.
+options:
+  _terms:
+    description: Um ou mais CIDRs de subnet, ex. V(10.150.5.0/24).
+    required: true
+  endpoint:
+    description: URL base da API do Bagre.
+    type: str
+    required: true
+    env:
+      - name: BAGRE_ENDPOINT
+  token:
+    description: Token de API do Bagre (C(bagre_...)).
+    type: str
+    required: true
+    env:
+      - name: BAGRE_TOKEN
+  validate_certs:
+    description: Valida o certificado TLS.
+    type: bool
+    default: true
+  timeout:
+    description: Timeout HTTP em segundos.
+    type: int
+    default: 30
+'''
+
+EXAMPLES = r'''
+- name: Aloca o próximo IP livre em uma variável
+  ansible.builtin.set_fact:
+    novo_ip: "{{ lookup('bagre.ipam.next_free_ip', '10.150.5.0/24') }}"
+  environment:
+    BAGRE_ENDPOINT: https://ipam.example.com
+    BAGRE_TOKEN: "{{ bagre_token }}"
+'''
+
+RETURN = r'''
+_raw:
+  description: Lista com o próximo IP livre (address) de cada subnet informada.
+  type: list
+  elements: str
+'''
+
+from ansible.errors import AnsibleError
+from ansible.plugins.lookup import LookupBase
+from ansible_collections.bagre.ipam.plugins.module_utils.bagre import (
+    BagreClient, BagreError, subnets_list_fn,
+)
+
+
+class LookupModule(LookupBase):
+
+    def run(self, terms, variables=None, **kwargs):
+        self.set_options(var_options=variables, direct=kwargs)
+        client = BagreClient(
+            endpoint=self.get_option('endpoint'),
+            token=self.get_option('token'),
+            validate_certs=self.get_option('validate_certs'),
+            timeout=self.get_option('timeout'),
+        )
+        try:
+            subnets = subnets_list_fn(client)
+            by_cidr = dict((str(sn.get('cidr')), sn.get('id')) for sn in subnets)
+            results = []
+            for term in terms:
+                subnet_id = by_cidr.get(str(term))
+                if subnet_id is None:
+                    raise AnsibleError("Subnet com CIDR '{0}' não encontrada.".format(term))
+                ip = client.get('/subnets/{0}/next-free-ip'.format(subnet_id))
+                address = ip.get('address') if isinstance(ip, dict) else ip
+                if not address:
+                    raise AnsibleError("Sem IP livre na subnet '{0}'.".format(term))
+                results.append(address)
+            return results
+        except BagreError as e:
+            raise AnsibleError(str(e))

--- a/ansible/plugins/module_utils/bagre.py
+++ b/ansible/plugins/module_utils/bagre.py
@@ -1,0 +1,256 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, Fabricio Cruz (@fabgcruz)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import json
+
+from ansible.module_utils.basic import env_fallback
+from ansible.module_utils.urls import open_url
+from ansible.module_utils.six.moves.urllib.error import HTTPError, URLError
+from ansible.module_utils.six.moves.urllib.parse import urlencode
+from ansible.module_utils.common.text.converters import to_native, to_text
+
+
+def bagre_argument_spec():
+    """Argumentos comuns de conexão a todos os módulos/plugins da collection."""
+    return dict(
+        endpoint=dict(
+            type='str', required=True,
+            fallback=(env_fallback, ['BAGRE_ENDPOINT']),
+        ),
+        token=dict(
+            type='str', required=True, no_log=True,
+            fallback=(env_fallback, ['BAGRE_TOKEN']),
+        ),
+        validate_certs=dict(type='bool', default=True),
+        timeout=dict(type='int', default=30),
+    )
+
+
+class BagreError(Exception):
+    def __init__(self, msg, status=None, body=None):
+        super(BagreError, self).__init__(msg)
+        self.status = status
+        self.body = body
+
+
+class BagreClient(object):
+    """Cliente HTTP minimalista para a API REST do Bagre (Bearer token)."""
+
+    def __init__(self, endpoint, token, validate_certs=True, timeout=30):
+        self.endpoint = endpoint.rstrip('/')
+        self.token = token
+        self.validate_certs = validate_certs
+        self.timeout = timeout
+
+    @classmethod
+    def from_module(cls, module):
+        p = module.params
+        return cls(p['endpoint'], p['token'],
+                   p.get('validate_certs', True), p.get('timeout', 30))
+
+    def _url(self, path, query=None):
+        if not path.startswith('/'):
+            path = '/' + path
+        url = '{0}/api{1}'.format(self.endpoint, path)
+        if query:
+            clean = dict((k, v) for k, v in query.items() if v is not None)
+            if clean:
+                url = url + '?' + urlencode(clean)
+        return url
+
+    def request(self, method, path, data=None, query=None):
+        url = self._url(path, query=query)
+        headers = {
+            'Authorization': 'Bearer ' + self.token,
+            'Accept': 'application/json',
+            'User-Agent': 'ansible-collection-bagre',
+        }
+        body = None
+        if data is not None:
+            headers['Content-Type'] = 'application/json'
+            body = json.dumps(data)
+        try:
+            resp = open_url(
+                url, method=method, data=body, headers=headers,
+                validate_certs=self.validate_certs, timeout=self.timeout,
+            )
+            raw = resp.read()
+            return resp.getcode(), self._parse(raw)
+        except HTTPError as e:
+            raw = e.read()
+            parsed = self._parse(raw)
+            detail = parsed if parsed else to_native(raw)
+            raise BagreError(
+                "HTTP {0} em {1} {2}: {3}".format(e.code, method, path, detail),
+                status=e.code, body=parsed,
+            )
+        except URLError as e:
+            raise BagreError(
+                "Falha de conexão com {0}: {1}".format(url, to_native(e.reason)))
+
+    @staticmethod
+    def _parse(raw):
+        if not raw:
+            return None
+        try:
+            return json.loads(to_text(raw))
+        except ValueError:
+            return to_text(raw)
+
+    def get(self, path, query=None):
+        return self.request('GET', path, query=query)[1]
+
+    def post(self, path, data):
+        return self.request('POST', path, data=data)[1]
+
+    def patch(self, path, data):
+        return self.request('PATCH', path, data=data)[1]
+
+    def delete(self, path):
+        return self.request('DELETE', path)[1]
+
+
+def _api_field(resource, option):
+    """Traduz um nome de opção Ansible (snake_case) para o campo da API (camelCase)."""
+    return resource.get('field_map', {}).get(option, option)
+
+
+def _build_payload(module, resource, option_names):
+    payload = {}
+    for opt in option_names:
+        if module.params.get(opt) is not None:
+            payload[_api_field(resource, opt)] = module.params[opt]
+    return payload
+
+
+def _list_items(client, resource):
+    if 'list_fn' in resource:
+        return resource['list_fn'](client)
+    data = client.get(resource['list_path'])
+    if isinstance(data, dict):
+        # algumas rotas embrulham a lista numa chave
+        for key in ('items', 'data', resource['name'] + 's'):
+            if isinstance(data.get(key), list):
+                return data[key]
+        return []
+    return data or []
+
+
+def _find_existing(module, resource, items):
+    match_keys = resource['match_keys']
+    for item in items:
+        ok = True
+        for opt in match_keys:
+            want = module.params.get(opt)
+            have = item.get(_api_field(resource, opt))
+            if want is None or str(have) != str(want):
+                ok = False
+                break
+        if ok:
+            return item
+    return None
+
+
+def run_resource(module, resource):
+    """Executa CRUD idempotente para um recurso REST simples do Bagre.
+
+    resource = {
+        name, list_path/list_fn, create_path, item_path ('/x/{id}'),
+        match_keys[], create_keys[], update_keys[], field_map{}, id_field
+    }
+    """
+    client = BagreClient.from_module(module)
+    state = module.params['state']
+    id_field = resource.get('id_field', 'id')
+    result = dict(changed=False, resource=None, diff={})
+
+    try:
+        existing = _find_existing(module, resource, _list_items(client, resource))
+
+        if state == 'absent':
+            if existing:
+                result['changed'] = True
+                result['resource'] = existing
+                if not module.check_mode:
+                    client.delete(resource['item_path'].format(id=existing[id_field]))
+                    result['resource'] = None
+            module.exit_json(**result)
+
+        # state == present
+        if not existing:
+            payload = _build_payload(module, resource, resource['create_keys'])
+            result['changed'] = True
+            result['diff'] = {'before': {}, 'after': payload}
+            if module.check_mode:
+                result['resource'] = payload
+            else:
+                result['resource'] = client.post(resource['create_path'], payload)
+            module.exit_json(**result)
+
+        # já existe -> calcula diff nos campos atualizáveis
+        patch = {}
+        before = {}
+        for opt in resource['update_keys']:
+            want = module.params.get(opt)
+            if want is None:
+                continue
+            field = _api_field(resource, opt)
+            have = existing.get(field)
+            if str(have) != str(want):
+                patch[field] = want
+                before[field] = have
+
+        if patch:
+            result['changed'] = True
+            result['diff'] = {'before': before, 'after': patch}
+            if module.check_mode:
+                merged = dict(existing)
+                merged.update(patch)
+                result['resource'] = merged
+            else:
+                result['resource'] = client.patch(
+                    resource['item_path'].format(id=existing[id_field]), patch)
+        else:
+            result['resource'] = existing
+
+        module.exit_json(**result)
+
+    except BagreError as e:
+        module.fail_json(msg=to_native(e), status=e.status, body=e.body)
+
+
+def run_info(module, resource):
+    """Lista recursos, com filtros opcionais mapeados para query params."""
+    client = BagreClient.from_module(module)
+    try:
+        query = None
+        if resource.get('filter_keys'):
+            query = {}
+            for opt in resource['filter_keys']:
+                if module.params.get(opt) is not None:
+                    query[_api_field(resource, opt)] = module.params[opt]
+        if 'list_fn' in resource:
+            items = resource['list_fn'](client)
+        else:
+            items = client.get(resource['list_path'], query=query)
+            if isinstance(items, dict):
+                items = items.get('items', items)
+        module.exit_json(changed=False, **{resource['return_key']: items})
+    except BagreError as e:
+        module.fail_json(msg=to_native(e), status=e.status, body=e.body)
+
+
+def subnets_list_fn(client):
+    """Achata as subnets aninhadas retornadas por GET /api/sites."""
+    sites = client.get('/sites') or []
+    out = []
+    for site in sites:
+        for sn in site.get('subnets', []) or []:
+            item = dict(sn)
+            item.setdefault('siteId', site.get('id'))
+            out.append(item)
+    return out

--- a/ansible/plugins/modules/cloud_account.py
+++ b/ansible/plugins/modules/cloud_account.py
@@ -1,0 +1,115 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, Fabricio Cruz (@fabgcruz)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: cloud_account
+short_description: Gerencia contas cloud (AWS/Azure/GCP) no Bagre IPAM
+version_added: "1.0.0"
+description:
+  - Cria, atualiza ou remove uma conta cloud usada para sincronizar subnets/IPs
+    de AWS, Azure ou GCP.
+  - Idempotente pela chave única O(display_name).
+author:
+  - Fabricio Cruz (@fabgcruz)
+extends_documentation_fragment:
+  - bagre.ipam.bagre
+options:
+  display_name:
+    description: Nome de exibição único da conta, ex. V(Prod AWS).
+    type: str
+    required: true
+  provider:
+    description: Provedor de nuvem. Obrigatório ao criar.
+    type: str
+    choices: [AWS, AZURE, GCP]
+  scope:
+    description: Escopo/identificador da conta (ex. account id).
+    type: str
+  regions:
+    description: Lista de regiões a sincronizar.
+    type: list
+    elements: str
+  credentials_enc:
+    description: Credenciais (serão armazenadas cifradas pelo Bagre).
+    type: str
+  sync_mode:
+    description: Modo de sincronização.
+    type: str
+    choices: [READ_ONLY, READ_WRITE]
+    default: READ_ONLY
+  poll_interval_min:
+    description: Intervalo de polling em minutos.
+    type: int
+  state:
+    description: Se a conta deve existir (V(present)) ou não (V(absent)).
+    type: str
+    choices: [present, absent]
+    default: present
+'''
+
+EXAMPLES = r'''
+- name: Conecta uma conta AWS de produção
+  bagre.ipam.cloud_account:
+    endpoint: https://ipam.example.com
+    token: "{{ bagre_token }}"
+    display_name: Prod AWS
+    provider: AWS
+    scope: "123456789012"
+    regions: [us-east-1, sa-east-1]
+    sync_mode: READ_ONLY
+    poll_interval_min: 15
+    state: present
+'''
+
+RETURN = r'''
+resource:
+  description: A conta cloud após a operação (ou null se removida).
+  type: dict
+  returned: success
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.bagre.ipam.plugins.module_utils.bagre import (
+    bagre_argument_spec, run_resource,
+)
+
+
+def main():
+    argument_spec = bagre_argument_spec()
+    argument_spec.update(dict(
+        display_name=dict(type='str', required=True),
+        provider=dict(type='str', choices=['AWS', 'AZURE', 'GCP']),
+        scope=dict(type='str'),
+        regions=dict(type='list', elements='str'),
+        credentials_enc=dict(type='str', no_log=True),
+        sync_mode=dict(type='str', default='READ_ONLY',
+                       choices=['READ_ONLY', 'READ_WRITE']),
+        poll_interval_min=dict(type='int'),
+        state=dict(type='str', default='present', choices=['present', 'absent']),
+    ))
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    resource = dict(
+        name='cloud_account',
+        list_path='/cloud-accounts',
+        create_path='/cloud-accounts',
+        item_path='/cloud-accounts/{id}',
+        match_keys=['display_name'],
+        create_keys=['provider', 'display_name', 'scope', 'regions',
+                     'credentials_enc', 'sync_mode', 'poll_interval_min'],
+        update_keys=['scope', 'regions', 'sync_mode', 'poll_interval_min'],
+        field_map={'display_name': 'displayName', 'credentials_enc': 'credentialsEnc',
+                   'sync_mode': 'syncMode', 'poll_interval_min': 'pollIntervalMin'},
+    )
+    run_resource(module, resource)
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/plugins/modules/device.py
+++ b/ansible/plugins/modules/device.py
@@ -1,0 +1,123 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, Fabricio Cruz (@fabgcruz)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: device
+short_description: Gerencia devices (equipamentos/hosts) no Bagre IPAM
+version_added: "1.0.0"
+description:
+  - Cria, atualiza ou remove um device (servidor, switch, host) no Bagre.
+  - Idempotente pela chave única O(name).
+author:
+  - Fabricio Cruz (@fabgcruz)
+extends_documentation_fragment:
+  - bagre.ipam.bagre
+options:
+  name:
+    description: Nome único do device, ex. V(srv-prod-01).
+    type: str
+    required: true
+  type:
+    description: Tipo do device, ex. V(Servidor Linux).
+    type: str
+  vendor:
+    description: Fabricante, ex. V(Dell).
+    type: str
+  model:
+    description: Modelo, ex. V(PowerEdge R740).
+    type: str
+  serial:
+    description: Número de série.
+    type: str
+  os_info:
+    description: Sistema operacional, ex. V(Ubuntu 22.04).
+    type: str
+  role:
+    description: Função/papel, ex. V(Web Server).
+    type: str
+  site_id:
+    description: ID do site onde o device está.
+    type: int
+  owner_email:
+    description: E-mail do responsável.
+    type: str
+  notes:
+    description: Observações livres.
+    type: str
+  state:
+    description: Se o device deve existir (V(present)) ou não (V(absent)).
+    type: str
+    choices: [present, absent]
+    default: present
+'''
+
+EXAMPLES = r'''
+- name: Registra um servidor
+  bagre.ipam.device:
+    endpoint: https://ipam.example.com
+    token: "{{ bagre_token }}"
+    name: srv-prod-01
+    type: Servidor Linux
+    vendor: Dell
+    model: PowerEdge R740
+    os_info: Ubuntu 22.04
+    role: Web Server
+    site_id: 1
+    state: present
+'''
+
+RETURN = r'''
+resource:
+  description: O device após a operação (ou null se removido).
+  type: dict
+  returned: success
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.bagre.ipam.plugins.module_utils.bagre import (
+    bagre_argument_spec, run_resource,
+)
+
+
+def main():
+    argument_spec = bagre_argument_spec()
+    argument_spec.update(dict(
+        name=dict(type='str', required=True),
+        type=dict(type='str'),
+        vendor=dict(type='str'),
+        model=dict(type='str'),
+        serial=dict(type='str'),
+        os_info=dict(type='str'),
+        role=dict(type='str'),
+        site_id=dict(type='int'),
+        owner_email=dict(type='str'),
+        notes=dict(type='str'),
+        state=dict(type='str', default='present', choices=['present', 'absent']),
+    ))
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    resource = dict(
+        name='device',
+        list_path='/devices',
+        create_path='/devices',
+        item_path='/devices/{id}',
+        match_keys=['name'],
+        create_keys=['name', 'type', 'vendor', 'model', 'serial',
+                     'os_info', 'role', 'site_id', 'owner_email', 'notes'],
+        update_keys=['type', 'vendor', 'model', 'serial',
+                     'os_info', 'role', 'site_id', 'owner_email', 'notes'],
+        field_map={'os_info': 'osInfo', 'site_id': 'siteId',
+                   'owner_email': 'ownerEmail'},
+    )
+    run_resource(module, resource)
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/plugins/modules/device_info.py
+++ b/ansible/plugins/modules/device_info.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, Fabricio Cruz (@fabgcruz)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: device_info
+short_description: Lista devices do Bagre IPAM
+version_added: "1.0.0"
+description:
+  - Retorna os devices, com filtros opcionais.
+author:
+  - Fabricio Cruz (@fabgcruz)
+extends_documentation_fragment:
+  - bagre.ipam.bagre
+options:
+  q:
+    description: Busca textual (nome, tipo, etc).
+    type: str
+  site_id:
+    description: Filtra por ID de site.
+    type: int
+  type:
+    description: Filtra por tipo de device.
+    type: str
+  vendor:
+    description: Filtra por fabricante.
+    type: str
+'''
+
+EXAMPLES = r'''
+- name: Lista servidores do site 1
+  bagre.ipam.device_info:
+    endpoint: https://ipam.example.com
+    token: "{{ bagre_token }}"
+    site_id: 1
+  register: out
+'''
+
+RETURN = r'''
+devices:
+  description: Lista de devices.
+  type: list
+  elements: dict
+  returned: success
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.bagre.ipam.plugins.module_utils.bagre import (
+    bagre_argument_spec, run_info,
+)
+
+
+def main():
+    argument_spec = bagre_argument_spec()
+    argument_spec.update(dict(
+        q=dict(type='str'),
+        site_id=dict(type='int'),
+        type=dict(type='str'),
+        vendor=dict(type='str'),
+    ))
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+    run_info(module, dict(
+        list_path='/devices',
+        return_key='devices',
+        filter_keys=['q', 'site_id', 'type', 'vendor'],
+        field_map={'site_id': 'siteId'},
+    ))
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/plugins/modules/ip.py
+++ b/ansible/plugins/modules/ip.py
@@ -1,0 +1,200 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, Fabricio Cruz (@fabgcruz)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: ip
+short_description: Reserva, libera ou atualiza um endereço IP no Bagre IPAM
+version_added: "1.0.0"
+description:
+  - Opera sobre um IP existente de uma subnet. Os IPs são criados automaticamente
+    quando a subnet IPv4 é criada; este módulo altera o estado/metadados deles.
+  - Localize a subnet por O(subnet_id) ou O(subnet_cidr) e o IP por O(address).
+author:
+  - Fabricio Cruz (@fabgcruz)
+extends_documentation_fragment:
+  - bagre.ipam.bagre
+options:
+  address:
+    description: Endereço IP alvo, ex. V(10.150.5.20).
+    type: str
+    required: true
+  subnet_id:
+    description: ID da subnet que contém o IP.
+    type: int
+  subnet_cidr:
+    description: CIDR da subnet que contém o IP (alternativa a O(subnet_id)).
+    type: str
+  hostname:
+    description: Hostname associado ao IP (usado quando O(state=present)).
+    type: str
+  type:
+    description: Tipo do host (ex. Servidor).
+    type: str
+  function:
+    description: Função do host (ex. Web).
+    type: str
+  notes:
+    description: Observações.
+    type: str
+  mac_address:
+    description: Endereço MAC.
+    type: str
+  state:
+    description:
+      - V(present) atualiza os metadados (o Bagre infere status USED).
+      - V(reserved) marca o IP como reservado.
+      - V(released) libera o IP (status FREE, limpa metadados).
+    type: str
+    choices: [present, reserved, released]
+    default: present
+'''
+
+EXAMPLES = r'''
+- name: Reserva um IP para uso futuro
+  bagre.ipam.ip:
+    endpoint: https://ipam.example.com
+    token: "{{ bagre_token }}"
+    subnet_cidr: 10.150.5.0/24
+    address: 10.150.5.20
+    state: reserved
+
+- name: Atribui hostname e função a um IP
+  bagre.ipam.ip:
+    subnet_id: 12
+    address: 10.150.5.20
+    hostname: srv-web-01
+    type: Servidor
+    function: Web
+    state: present
+
+- name: Libera um IP
+  bagre.ipam.ip:
+    subnet_cidr: 10.150.5.0/24
+    address: 10.150.5.20
+    state: released
+'''
+
+RETURN = r'''
+resource:
+  description: O IP após a operação.
+  type: dict
+  returned: success
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_native
+from ansible_collections.bagre.ipam.plugins.module_utils.bagre import (
+    bagre_argument_spec, BagreClient, BagreError, subnets_list_fn,
+)
+
+_FIELD_MAP = {
+    'hostname': 'hostname', 'type': 'type', 'function': 'function',
+    'notes': 'notes', 'mac_address': 'macAddress',
+}
+
+
+def _resolve_subnet_id(module, client):
+    if module.params.get('subnet_id') is not None:
+        return module.params['subnet_id']
+    cidr = module.params.get('subnet_cidr')
+    for sn in subnets_list_fn(client):
+        if str(sn.get('cidr')) == str(cidr):
+            return sn.get('id')
+    module.fail_json(msg="Subnet com CIDR '{0}' não encontrada.".format(cidr))
+
+
+def _find_ip(client, subnet_id, address):
+    ips = client.get('/subnets/{0}/ips'.format(subnet_id), query={'q': address})
+    for ip in (ips or []):
+        if str(ip.get('address')) == str(address):
+            return ip
+    return None
+
+
+def main():
+    argument_spec = bagre_argument_spec()
+    argument_spec.update(dict(
+        address=dict(type='str', required=True),
+        subnet_id=dict(type='int'),
+        subnet_cidr=dict(type='str'),
+        hostname=dict(type='str'),
+        type=dict(type='str'),
+        function=dict(type='str'),
+        notes=dict(type='str'),
+        mac_address=dict(type='str'),
+        state=dict(type='str', default='present',
+                   choices=['present', 'reserved', 'released']),
+    ))
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_one_of=[['subnet_id', 'subnet_cidr']],
+        mutually_exclusive=[['subnet_id', 'subnet_cidr']],
+    )
+
+    client = BagreClient.from_module(module)
+    address = module.params['address']
+    state = module.params['state']
+    result = dict(changed=False, resource=None)
+
+    try:
+        subnet_id = _resolve_subnet_id(module, client)
+        ip = _find_ip(client, subnet_id, address)
+        if not ip:
+            module.fail_json(
+                msg="IP {0} não encontrado na subnet {1}. Em IPv4 os IPs são "
+                    "criados junto com a subnet; em IPv6 crie o IP antes."
+                    .format(address, subnet_id))
+
+        ip_id = ip['id']
+
+        if state == 'released':
+            if ip.get('status') != 'FREE':
+                result['changed'] = True
+                result['resource'] = ip if module.check_mode else \
+                    client.post('/ips/{0}/release'.format(ip_id), data={})
+            else:
+                result['resource'] = ip
+            module.exit_json(**result)
+
+        if state == 'reserved':
+            if ip.get('status') != 'RESERVED':
+                result['changed'] = True
+                result['resource'] = ip if module.check_mode else \
+                    client.post('/ips/{0}/reserve'.format(ip_id), data={})
+            else:
+                result['resource'] = ip
+            module.exit_json(**result)
+
+        # state == present -> PATCH metadados
+        patch = {}
+        for opt, field in _FIELD_MAP.items():
+            want = module.params.get(opt)
+            if want is not None and str(ip.get(field)) != str(want):
+                patch[field] = want
+        if patch:
+            result['changed'] = True
+            if module.check_mode:
+                merged = dict(ip)
+                merged.update(patch)
+                result['resource'] = merged
+            else:
+                result['resource'] = client.patch('/ips/{0}'.format(ip_id), patch)
+        else:
+            result['resource'] = ip
+
+        module.exit_json(**result)
+
+    except BagreError as e:
+        module.fail_json(msg=to_native(e), status=e.status, body=e.body)
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/plugins/modules/ip_info.py
+++ b/ansible/plugins/modules/ip_info.py
@@ -1,0 +1,100 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, Fabricio Cruz (@fabgcruz)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: ip_info
+short_description: Lista IPs de uma subnet no Bagre IPAM
+version_added: "1.0.0"
+description:
+  - Retorna os IPs de uma subnet, com filtros opcionais de status e busca.
+  - Localize a subnet por O(subnet_id) ou O(subnet_cidr).
+author:
+  - Fabricio Cruz (@fabgcruz)
+extends_documentation_fragment:
+  - bagre.ipam.bagre
+options:
+  subnet_id:
+    description: ID da subnet.
+    type: int
+  subnet_cidr:
+    description: CIDR da subnet (alternativa a O(subnet_id)).
+    type: str
+  status:
+    description: Filtra por status do IP.
+    type: str
+    choices: [FREE, USED, RESERVED, CONFLICT]
+  q:
+    description: Busca textual (address, hostname, type, function).
+    type: str
+'''
+
+EXAMPLES = r'''
+- name: Lista IPs livres de uma subnet
+  bagre.ipam.ip_info:
+    endpoint: https://ipam.example.com
+    token: "{{ bagre_token }}"
+    subnet_cidr: 10.150.5.0/24
+    status: FREE
+  register: out
+'''
+
+RETURN = r'''
+ips:
+  description: Lista de IPs da subnet.
+  type: list
+  elements: dict
+  returned: success
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_native
+from ansible_collections.bagre.ipam.plugins.module_utils.bagre import (
+    bagre_argument_spec, BagreClient, BagreError, subnets_list_fn,
+)
+
+
+def main():
+    argument_spec = bagre_argument_spec()
+    argument_spec.update(dict(
+        subnet_id=dict(type='int'),
+        subnet_cidr=dict(type='str'),
+        status=dict(type='str',
+                    choices=['FREE', 'USED', 'RESERVED', 'CONFLICT']),
+        q=dict(type='str'),
+    ))
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_one_of=[['subnet_id', 'subnet_cidr']],
+        mutually_exclusive=[['subnet_id', 'subnet_cidr']],
+    )
+
+    client = BagreClient.from_module(module)
+    try:
+        subnet_id = module.params.get('subnet_id')
+        if subnet_id is None:
+            cidr = module.params['subnet_cidr']
+            subnet_id = next((sn.get('id') for sn in subnets_list_fn(client)
+                              if str(sn.get('cidr')) == str(cidr)), None)
+            if subnet_id is None:
+                module.fail_json(msg="Subnet com CIDR '{0}' não encontrada.".format(cidr))
+        query = {}
+        if module.params.get('status'):
+            query['status'] = module.params['status']
+        if module.params.get('q'):
+            query['q'] = module.params['q']
+        ips = client.get('/subnets/{0}/ips'.format(subnet_id), query=query or None)
+        module.exit_json(changed=False, ips=ips or [])
+    except BagreError as e:
+        module.fail_json(msg=to_native(e), status=e.status, body=e.body)
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/plugins/modules/master_range.py
+++ b/ansible/plugins/modules/master_range.py
@@ -1,0 +1,90 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, Fabricio Cruz (@fabgcruz)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: master_range
+short_description: Gerencia master ranges (faixas corporativas) no Bagre IPAM
+version_added: "1.0.0"
+description:
+  - Cria, atualiza ou remove um master range — o catálogo de faixas CIDR
+    corporativas usadas pela validação C(within-master).
+  - Idempotente pela chave única O(cidr).
+author:
+  - Fabricio Cruz (@fabgcruz)
+extends_documentation_fragment:
+  - bagre.ipam.bagre
+options:
+  cidr:
+    description: Faixa em notação CIDR, ex. V(10.0.0.0/8).
+    type: str
+    required: true
+  description:
+    description: Descrição da faixa.
+    type: str
+  category:
+    description: Categoria da faixa.
+    type: str
+    choices: [Datacenter, Cloud, Links, WAN]
+  state:
+    description: Se a faixa deve existir (V(present)) ou não (V(absent)).
+    type: str
+    choices: [present, absent]
+    default: present
+'''
+
+EXAMPLES = r'''
+- name: Registra a faixa corporativa 10/8
+  bagre.ipam.master_range:
+    endpoint: https://ipam.example.com
+    token: "{{ bagre_token }}"
+    cidr: 10.0.0.0/8
+    description: Faixa privada da empresa
+    category: Datacenter
+    state: present
+'''
+
+RETURN = r'''
+resource:
+  description: O master range após a operação (ou null se removido).
+  type: dict
+  returned: success
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.bagre.ipam.plugins.module_utils.bagre import (
+    bagre_argument_spec, run_resource,
+)
+
+
+def main():
+    argument_spec = bagre_argument_spec()
+    argument_spec.update(dict(
+        cidr=dict(type='str', required=True),
+        description=dict(type='str'),
+        category=dict(type='str',
+                      choices=['Datacenter', 'Cloud', 'Links', 'WAN']),
+        state=dict(type='str', default='present', choices=['present', 'absent']),
+    ))
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    resource = dict(
+        name='master_range',
+        list_path='/master-ranges',
+        create_path='/master-ranges',
+        item_path='/master-ranges/{id}',
+        match_keys=['cidr'],
+        create_keys=['cidr', 'description', 'category'],
+        update_keys=['description', 'category'],
+    )
+    run_resource(module, resource)
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/plugins/modules/next_free_ip.py
+++ b/ansible/plugins/modules/next_free_ip.py
@@ -1,0 +1,87 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, Fabricio Cruz (@fabgcruz)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: next_free_ip
+short_description: Retorna o próximo IP livre de uma subnet no Bagre IPAM
+version_added: "1.0.0"
+description:
+  - Consulta (read-only) o próximo endereço IP livre de uma subnet.
+  - Localize a subnet por O(subnet_id) ou O(subnet_cidr).
+author:
+  - Fabricio Cruz (@fabgcruz)
+extends_documentation_fragment:
+  - bagre.ipam.bagre
+options:
+  subnet_id:
+    description: ID da subnet.
+    type: int
+  subnet_cidr:
+    description: CIDR da subnet (alternativa a O(subnet_id)).
+    type: str
+'''
+
+EXAMPLES = r'''
+- name: Descobre o próximo IP livre
+  bagre.ipam.next_free_ip:
+    endpoint: https://ipam.example.com
+    token: "{{ bagre_token }}"
+    subnet_cidr: 10.150.5.0/24
+  register: livre
+
+- name: Mostra o IP
+  ansible.builtin.debug:
+    msg: "Próximo IP livre: {{ livre.ip.address }}"
+'''
+
+RETURN = r'''
+ip:
+  description: Objeto do próximo IP livre retornado pela API.
+  type: dict
+  returned: success
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_native
+from ansible_collections.bagre.ipam.plugins.module_utils.bagre import (
+    bagre_argument_spec, BagreClient, BagreError, subnets_list_fn,
+)
+
+
+def main():
+    argument_spec = bagre_argument_spec()
+    argument_spec.update(dict(
+        subnet_id=dict(type='int'),
+        subnet_cidr=dict(type='str'),
+    ))
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_one_of=[['subnet_id', 'subnet_cidr']],
+        mutually_exclusive=[['subnet_id', 'subnet_cidr']],
+    )
+
+    client = BagreClient.from_module(module)
+    try:
+        subnet_id = module.params.get('subnet_id')
+        if subnet_id is None:
+            cidr = module.params['subnet_cidr']
+            subnet_id = next((sn.get('id') for sn in subnets_list_fn(client)
+                              if str(sn.get('cidr')) == str(cidr)), None)
+            if subnet_id is None:
+                module.fail_json(msg="Subnet com CIDR '{0}' não encontrada.".format(cidr))
+        ip = client.get('/subnets/{0}/next-free-ip'.format(subnet_id))
+        module.exit_json(changed=False, ip=ip)
+    except BagreError as e:
+        module.fail_json(msg=to_native(e), status=e.status, body=e.body)
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/plugins/modules/site.py
+++ b/ansible/plugins/modules/site.py
@@ -1,0 +1,98 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, Fabricio Cruz (@fabgcruz)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: site
+short_description: Gerencia sites (locais/datacenters) no Bagre IPAM
+version_added: "1.0.0"
+description:
+  - Cria, atualiza ou remove um site no Bagre. Um site representa um local
+    físico (datacenter, escritório) que agrupa subnets e IPs.
+  - A operação é idempotente e usa O(code) como chave única.
+author:
+  - Fabricio Cruz (@fabgcruz)
+extends_documentation_fragment:
+  - bagre.ipam.bagre
+options:
+  code:
+    description: Código único do site, ex. V(DC1).
+    type: str
+    required: true
+  name:
+    description: Nome legível do site. Obrigatório ao criar.
+    type: str
+  description:
+    description: Descrição livre do site.
+    type: str
+  state:
+    description: Se o site deve existir (V(present)) ou não (V(absent)).
+    type: str
+    choices: [present, absent]
+    default: present
+'''
+
+EXAMPLES = r'''
+- name: Garante que o datacenter DC1 existe
+  bagre.ipam.site:
+    endpoint: https://ipam.example.com
+    token: "{{ bagre_token }}"
+    code: DC1
+    name: Data Center 1
+    description: Sala cofre - São Paulo
+    state: present
+
+- name: Remove um site
+  bagre.ipam.site:
+    code: DC1
+    state: absent
+'''
+
+RETURN = r'''
+resource:
+  description: O site após a operação (ou null se removido).
+  type: dict
+  returned: success
+  sample:
+    id: 1
+    code: DC1
+    name: Data Center 1
+    description: Sala cofre - São Paulo
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.bagre.ipam.plugins.module_utils.bagre import (
+    bagre_argument_spec, run_resource,
+)
+
+
+def main():
+    argument_spec = bagre_argument_spec()
+    argument_spec.update(dict(
+        code=dict(type='str', required=True),
+        name=dict(type='str'),
+        description=dict(type='str'),
+        state=dict(type='str', default='present', choices=['present', 'absent']),
+    ))
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    resource = dict(
+        name='site',
+        list_path='/sites',
+        create_path='/sites',
+        item_path='/sites/{id}',
+        match_keys=['code'],
+        create_keys=['code', 'name', 'description'],
+        update_keys=['name', 'description'],
+    )
+    run_resource(module, resource)
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/plugins/modules/site_info.py
+++ b/ansible/plugins/modules/site_info.py
@@ -1,0 +1,54 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, Fabricio Cruz (@fabgcruz)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: site_info
+short_description: Lista sites do Bagre IPAM
+version_added: "1.0.0"
+description:
+  - Retorna todos os sites (com subnets aninhadas).
+author:
+  - Fabricio Cruz (@fabgcruz)
+extends_documentation_fragment:
+  - bagre.ipam.bagre
+'''
+
+EXAMPLES = r'''
+- name: Lista os sites
+  bagre.ipam.site_info:
+    endpoint: https://ipam.example.com
+    token: "{{ bagre_token }}"
+  register: out
+
+- ansible.builtin.debug:
+    var: out.sites
+'''
+
+RETURN = r'''
+sites:
+  description: Lista de sites.
+  type: list
+  elements: dict
+  returned: success
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.bagre.ipam.plugins.module_utils.bagre import (
+    bagre_argument_spec, run_info,
+)
+
+
+def main():
+    module = AnsibleModule(argument_spec=bagre_argument_spec(),
+                           supports_check_mode=True)
+    run_info(module, dict(list_path='/sites', return_key='sites'))
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/plugins/modules/subnet.py
+++ b/ansible/plugins/modules/subnet.py
@@ -1,0 +1,98 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, Fabricio Cruz (@fabgcruz)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: subnet
+short_description: Gerencia subnets (redes CIDR) no Bagre IPAM
+version_added: "1.0.0"
+description:
+  - Cria, atualiza ou remove uma subnet. Ao criar com um CIDR IPv4, o Bagre
+    expande automaticamente os IPs (até 4096 por subnet).
+  - Idempotente pela chave única O(cidr). O CIDR não pode ser alterado após criado.
+author:
+  - Fabricio Cruz (@fabgcruz)
+extends_documentation_fragment:
+  - bagre.ipam.bagre
+options:
+  cidr:
+    description: Rede em notação CIDR, ex. V(10.150.5.0/24).
+    type: str
+    required: true
+  site_id:
+    description: ID do site ao qual a subnet pertence. Obrigatório ao criar.
+    type: int
+  name:
+    description: Nome da subnet, ex. V(LAN-PROD).
+    type: str
+  vlan_id:
+    description: ID da VLAN associada.
+    type: int
+  description:
+    description: Descrição livre.
+    type: str
+  state:
+    description: Se a subnet deve existir (V(present)) ou não (V(absent)).
+    type: str
+    choices: [present, absent]
+    default: present
+'''
+
+EXAMPLES = r'''
+- name: Cria a subnet de produção no site 1
+  bagre.ipam.subnet:
+    endpoint: https://ipam.example.com
+    token: "{{ bagre_token }}"
+    site_id: 1
+    name: LAN-PROD
+    cidr: 10.150.5.0/24
+    vlan_id: 510
+    state: present
+'''
+
+RETURN = r'''
+resource:
+  description: A subnet após a operação (ou null se removida).
+  type: dict
+  returned: success
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.bagre.ipam.plugins.module_utils.bagre import (
+    bagre_argument_spec, run_resource, subnets_list_fn,
+)
+
+
+def main():
+    argument_spec = bagre_argument_spec()
+    argument_spec.update(dict(
+        cidr=dict(type='str', required=True),
+        site_id=dict(type='int'),
+        name=dict(type='str'),
+        vlan_id=dict(type='int'),
+        description=dict(type='str'),
+        state=dict(type='str', default='present', choices=['present', 'absent']),
+    ))
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    resource = dict(
+        name='subnet',
+        list_fn=subnets_list_fn,
+        create_path='/subnets',
+        item_path='/subnets/{id}',
+        match_keys=['cidr'],
+        create_keys=['site_id', 'name', 'cidr', 'vlan_id', 'description'],
+        update_keys=['name', 'vlan_id', 'description'],
+        field_map={'site_id': 'siteId', 'vlan_id': 'vlanId'},
+    )
+    run_resource(module, resource)
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/plugins/modules/subnet_info.py
+++ b/ansible/plugins/modules/subnet_info.py
@@ -1,0 +1,54 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, Fabricio Cruz (@fabgcruz)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: subnet_info
+short_description: Lista subnets do Bagre IPAM
+version_added: "1.0.0"
+description:
+  - Retorna todas as subnets cadastradas (achatadas a partir dos sites).
+author:
+  - Fabricio Cruz (@fabgcruz)
+extends_documentation_fragment:
+  - bagre.ipam.bagre
+'''
+
+EXAMPLES = r'''
+- name: Lista as subnets
+  bagre.ipam.subnet_info:
+    endpoint: https://ipam.example.com
+    token: "{{ bagre_token }}"
+  register: out
+
+- ansible.builtin.debug:
+    var: out.subnets
+'''
+
+RETURN = r'''
+subnets:
+  description: Lista de subnets.
+  type: list
+  elements: dict
+  returned: success
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.bagre.ipam.plugins.module_utils.bagre import (
+    bagre_argument_spec, run_info, subnets_list_fn,
+)
+
+
+def main():
+    module = AnsibleModule(argument_spec=bagre_argument_spec(),
+                           supports_check_mode=True)
+    run_info(module, dict(list_fn=subnets_list_fn, return_key='subnets'))
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/plugins/modules/validation_rule.py
+++ b/ansible/plugins/modules/validation_rule.py
@@ -1,0 +1,108 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, Fabricio Cruz (@fabgcruz)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: validation_rule
+short_description: Gerencia regras de validação de subnets no Bagre IPAM
+version_added: "1.0.0"
+description:
+  - Cria, atualiza ou remove uma regra de validação aplicada na criação de subnets
+    (ex. C(no-overlap), C(within-master), C(size-range), C(name-pattern)).
+  - Idempotente pela chave única O(name).
+author:
+  - Fabricio Cruz (@fabgcruz)
+extends_documentation_fragment:
+  - bagre.ipam.bagre
+options:
+  name:
+    description: Nome único da regra.
+    type: str
+    required: true
+  rule_type:
+    description: Tipo da regra. Obrigatório ao criar.
+    type: str
+    choices: [no-overlap, within-master, size-range, name-pattern]
+  enabled:
+    description: Se a regra está habilitada.
+    type: bool
+    default: true
+  scope:
+    description: Escopo de aplicação (ex. V(null), V("siteId"), V("provider:aws")).
+    type: str
+  config:
+    description: Configuração específica da regra (objeto livre).
+    type: dict
+  severity:
+    description: Severidade quando a regra falha.
+    type: str
+    choices: [error, warning]
+    default: error
+  state:
+    description: Se a regra deve existir (V(present)) ou não (V(absent)).
+    type: str
+    choices: [present, absent]
+    default: present
+'''
+
+EXAMPLES = r'''
+- name: Garante regra global de não-sobreposição
+  bagre.ipam.validation_rule:
+    endpoint: https://ipam.example.com
+    token: "{{ bagre_token }}"
+    name: global-no-overlap
+    rule_type: no-overlap
+    enabled: true
+    severity: error
+    state: present
+'''
+
+RETURN = r'''
+resource:
+  description: A regra após a operação (ou null se removida).
+  type: dict
+  returned: success
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.bagre.ipam.plugins.module_utils.bagre import (
+    bagre_argument_spec, run_resource,
+)
+
+
+def main():
+    argument_spec = bagre_argument_spec()
+    argument_spec.update(dict(
+        name=dict(type='str', required=True),
+        rule_type=dict(type='str',
+                       choices=['no-overlap', 'within-master',
+                                'size-range', 'name-pattern']),
+        enabled=dict(type='bool', default=True),
+        scope=dict(type='str'),
+        config=dict(type='dict'),
+        severity=dict(type='str', default='error', choices=['error', 'warning']),
+        state=dict(type='str', default='present', choices=['present', 'absent']),
+    ))
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    resource = dict(
+        name='validation_rule',
+        list_path='/validation/rules',
+        create_path='/validation/rules',
+        item_path='/validation/rules/{id}',
+        match_keys=['name'],
+        create_keys=['name', 'rule_type', 'enabled', 'scope', 'config', 'severity'],
+        update_keys=['enabled', 'scope', 'config', 'severity'],
+        field_map={'rule_type': 'ruleType'},
+    )
+    run_resource(module, resource)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## O que é

Primeira versão da **Ansible Collection `bagre.ipam`** — automação operacional do Bagre IPAM via Ansible, pronta para publicação no Ansible Galaxy. Faz par com o `terraform-provider-bagre` (IaC via Terraform, operação via Ansible).

Vive em `ansible/` dentro do monorepo. **Não altera o produto** (apps/api, web) nem nada em produção.

## Conteúdo

**Módulos (CRUD, idempotentes, com check_mode):**
`site`, `subnet`, `ip`, `device`, `master_range`, `validation_rule`, `cloud_account`

**Consulta (read-only):**
`site_info`, `subnet_info`, `device_info`, `ip_info`, `next_free_ip`

**Plugins:**
- `inventory` — inventário dinâmico a partir dos IPs do Bagre (hosts, grupos por site/função, `ansible_host`)
- `lookup next_free_ip` — próximo IP livre dentro de expressões Jinja

**Infra:**
- Cliente HTTP + engine de CRUD compartilhado (`module_utils`), Bearer token, envs `BAGRE_ENDPOINT` / `BAGRE_TOKEN` (mesma convenção do Terraform provider)
- Docs (`README.md`), exemplos (`playbooks/`) e CI (`.github/workflows/ansible-collection.yml`): build + `ansible-test sanity` + publish no Galaxy por tag `ansible-v*`

## Decisões de design

- **Namespace `bagre.ipam`** (requer reivindicar o namespace `bagre` no Galaxy).
- **Fora do escopo:** gestão de usuários e de API tokens — a API bloqueia esses endpoints para tokens de automação (só admin via UI/JWT).
- **Licença:** MIT (consistente com o monorepo).

## Como testar

```bash
export BAGRE_ENDPOINT=https://ipam.example.com
export BAGRE_TOKEN=bagre_xxxxxxxx
ansible-galaxy collection build ansible
ansible-playbook ansible/playbooks/exemplo.yml
```

Relacionado: #15